### PR TITLE
Add support for remote DOCKER_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ It is important that the host of your private repositories has already been adde
 `$HOME/.ssh/known_hosts` file, as the install process will fail otherwise due to host authenticity
 failure.
 
+### Remote docker hosts
+
+If you have DOCKER_HOST set to a remote mahine, you must set the following option. This tells the plugin
+not to try and mount the local filesystem to the container (which will not work over a network). Instead
+it uses a Docker volume and copies the files across.
+
+Additionally, if you are in a corporate network and there is a proxy, you can define this in the `proxy` option. 
+This will set the http and https proxy inside the container.
+
+```yaml 
+custom:
+  pythonRequirements:
+    dockerizePip: true
+    dockerRemoteHost: true
+    proxy: http://yourproxy:8080
+```
+
 [:checkered_flag: Windows notes](#checkered_flag-windows-dockerizepip-notes)
 
 ## Pipenv support :sparkles::cake::sparkles:

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -146,13 +146,51 @@ function installRequirements(targetFolder, serverless, options) {
     }
     serverless.cli.log(`Docker Image: ${dockerImage}`);
 
-    // Prepare bind path depending on os platform
-    const bindPath = dockerPathForWin(
-      options,
-      getBindPath(serverless, targetFolder)
-    );
+    var bindPath = ''; // Set this depending on whether remote host is being used.
 
-    cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
+    // If Docker is using a remote host, we can't mount local files. Need to use data volume instead, and copy files in.
+    if (options.dockerRemoteHost) {
+
+      // docker volume create data-volume
+      serverless.cli.log("Remote docker option selected")
+      serverless.cli.log("Creating data volume")
+      cmdOptions = ['volume', 'create', 'data-volume' ] // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+
+      // docker create -v data-volume:/var/task --name helper (imagename) true
+      serverless.cli.log("Mounting data volume to helper container")
+      cmdOptions = [ 'create', '-v', 'data-volume:/var/task', '--name', 'helper', dockerImage, 'true']
+      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+
+      // copy the files onto the volume
+      serverless.cli.log("Copying files onto volume")
+      cmdOptions = ['cp', dockerPathForWin(options, targetFolder), 'helper:/var/task' ] // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+
+      // remove the helper container - not needed any more
+      serverless.cli.log("Removing helper image")
+      cmdOptions = ['rm', 'helper' ] // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+
+      // Now set bindPath to the data volume (rather than a local folder)
+      bindPath = "data-volume"
+      cmdOptions = [];
+      
+    } else {
+
+      // Prepare bind path depending on os platform
+      bindPath = dockerPathForWin(
+        options,
+        getBindPath(serverless, targetFolder)
+      );
+    }
+
+    cmdOptions = ['run', '--name', 'python-reqs', '-v', `${bindPath}:/var/task:z` ];
+    
+    if (options.proxy) {
+      cmdOptions.push('--env', `http_proxy=${options.proxy}`, '--env', `https_proxy=${options.proxy}`)
+    }
+    
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
@@ -242,9 +280,34 @@ function installRequirements(targetFolder, serverless, options) {
     const preparedPath = dockerPathForWin(options, targetFolder);
     cmdOptions.push(getStripCommand(options, preparedPath));
   }
+
+  executeCmdAsSpawnSync(cmd, cmdOptions, options);
+
+
+
+  if (options.dockerRemoteHost) {
+    // copy the files back from the data volume
+    serverless.cli.log("Copying python libraries off docker container, ready for zipping")
+    cmdOptions = ['cp', 'python-reqs:/var/task/.', targetFolder] // volume create data-volume
+    executeCmdAsSpawnSync(cmd, cmdOptions, options)
+  }
+
+  // remove the container - not needed any more
+  serverless.cli.log("Removing container image")
+  cmdOptions = ['rm', 'python-reqs' ] // volume create data-volume
+  executeCmdAsSpawnSync(cmd, cmdOptions, options)
+
+  // If enabled slimming, delete files in slimPatterns
+  if (options.slim === true || options.slim === 'true') {
+    deleteFiles(options, targetFolder);
+  }
+}
+
+function executeCmdAsSpawnSync(cmd, cmdOptions, options) {
   let spawnArgs = { shell: true };
   if (process.env.SLS_DEBUG) {
     spawnArgs.stdio = 'inherit';
+    console.log(`> spawning cmd: ${cmd} ${cmdOptions.toString()}`)
   }
   const res = spawnSync(cmd, cmdOptions, spawnArgs);
   if (res.error) {
@@ -252,18 +315,12 @@ function installRequirements(targetFolder, serverless, options) {
       if (options.dockerizePip) {
         throw new Error('docker not found! Please install it.');
       }
-      throw new Error(
-        `${options.pythonBin} not found! Try the pythonBin option.`
-      );
+      throw new Error(`${options.pythonBin} not found! Try the pythonBin option.`);
     }
     throw res.error;
   }
   if (res.status !== 0) {
     throw new Error(res.stderr);
-  }
-  // If enabled slimming, delete files in slimPatterns
-  if (options.slim === true || options.slim === 'true') {
-    deleteFiles(options, targetFolder);
   }
 }
 
@@ -274,10 +331,8 @@ function installRequirements(targetFolder, serverless, options) {
  * @return {string}
  */
 function dockerPathForWin(options, path) {
-  if (process.platform === 'win32') {
-    return `"${path.replace(/\\/g, '/')}"`;
-  } else if (process.platform === 'win32' && !options.dockerizePip) {
-    return path;
+  if (process.platform === 'win32' && options.dockerizePip) {
+    return path.replace(/\\/g, '/');
   }
   return quote_single(path);
 }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -283,19 +283,20 @@ function installRequirements(targetFolder, serverless, options) {
 
   executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
+  if (options.dockerizePip) {
+    if (options.dockerRemoteHost) {
+      // copy the files back from the data volume
+      serverless.cli.log("Copying python libraries off docker container, ready for zipping")
+      cmdOptions = ['cp', 'python-reqs:/var/task/.', targetFolder] // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+    }
 
-
-  if (options.dockerRemoteHost) {
-    // copy the files back from the data volume
-    serverless.cli.log("Copying python libraries off docker container, ready for zipping")
-    cmdOptions = ['cp', 'python-reqs:/var/task/.', targetFolder] // volume create data-volume
+    // remove the container - not needed any more
+    serverless.cli.log("Removing container image")
+    cmdOptions = ['rm', 'python-reqs' ] // volume create data-volume
     executeCmdAsSpawnSync(cmd, cmdOptions, options)
-  }
 
-  // remove the container - not needed any more
-  serverless.cli.log("Removing container image")
-  cmdOptions = ['rm', 'python-reqs' ] // volume create data-volume
-  executeCmdAsSpawnSync(cmd, cmdOptions, options)
+  }
 
   // If enabled slimming, delete files in slimPatterns
   if (options.slim === true || options.slim === 'true') {
@@ -307,7 +308,6 @@ function executeCmdAsSpawnSync(cmd, cmdOptions, options) {
   let spawnArgs = { shell: true };
   if (process.env.SLS_DEBUG) {
     spawnArgs.stdio = 'inherit';
-    console.log(`> spawning cmd: ${cmd} ${cmdOptions.toString()}`)
   }
   const res = spawnSync(cmd, cmdOptions, spawnArgs);
   if (res.error) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -78,15 +78,15 @@ function installRequirements(targetFolder, serverless, options) {
   if (options.pipCmdExtraArgs.indexOf('--cache-dir') > -1) {
     if (options.dockerizePip) {
       throw 'Error: You can not use --cache-dir with Docker any more, please\n' +
-        '         use the new option useDownloadCache instead.  Please see:\n' +
-        '         https://github.com/UnitedIncome/serverless-python-requirements#caching';
+      '         use the new option useDownloadCache instead.  Please see:\n' +
+      '         https://github.com/UnitedIncome/serverless-python-requirements#caching';
     } else {
       serverless.cli.log('==================================================');
       serverless.cli.log(
         'Warning: You are using a deprecated --cache-dir inside\n' +
-          '            your pipCmdExtraArgs which may not work properly, please use the\n' +
-          '            useDownloadCache option instead.  Please see: \n' +
-          '            https://github.com/UnitedIncome/serverless-python-requirements#caching'
+        '            your pipCmdExtraArgs which may not work properly, please use the\n' +
+        '            useDownloadCache option instead.  Please see: \n' +
+        '            https://github.com/UnitedIncome/serverless-python-requirements#caching'
       );
       serverless.cli.log('==================================================');
     }
@@ -150,34 +150,43 @@ function installRequirements(targetFolder, serverless, options) {
 
     // If Docker is using a remote host, we can't mount local files. Need to use data volume instead, and copy files in.
     if (options.dockerRemoteHost) {
-
       // docker volume create data-volume
-      serverless.cli.log("Remote docker option selected")
-      serverless.cli.log("Creating data volume")
-      cmdOptions = ['volume', 'create', 'data-volume' ] // volume create data-volume
-      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+      serverless.cli.log('Remote docker option selected');
+      serverless.cli.log('Creating data volume');
+      cmdOptions = ['volume', 'create', 'data-volume']; // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
       // docker create -v data-volume:/var/task --name helper (imagename) true
-      serverless.cli.log("Mounting data volume to helper container")
-      cmdOptions = [ 'create', '-v', 'data-volume:/var/task', '--name', 'helper', dockerImage, 'true']
-      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+      serverless.cli.log('Mounting data volume to helper container');
+      cmdOptions = [
+        'create',
+        '-v',
+        'data-volume:/var/task',
+        '--name',
+        'helper',
+        dockerImage,
+        'true'
+      ];
+      executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
       // copy the files onto the volume
-      serverless.cli.log("Copying files onto volume")
-      cmdOptions = ['cp', dockerPathForWin(options, targetFolder), 'helper:/var/task' ] // volume create data-volume
-      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+      serverless.cli.log('Copying files onto volume');
+      cmdOptions = [
+        'cp',
+        dockerPathForWin(options, targetFolder),
+        'helper:/var/task'
+      ]; // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
       // remove the helper container - not needed any more
-      serverless.cli.log("Removing helper image")
-      cmdOptions = ['rm', 'helper' ] // volume create data-volume
-      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+      serverless.cli.log('Removing helper image');
+      cmdOptions = ['rm', 'helper']; // volume create data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
       // Now set bindPath to the data volume (rather than a local folder)
-      bindPath = "data-volume"
+      bindPath = 'data-volume';
       cmdOptions = [];
-      
     } else {
-
       // Prepare bind path depending on os platform
       bindPath = dockerPathForWin(
         options,
@@ -185,12 +194,23 @@ function installRequirements(targetFolder, serverless, options) {
       );
     }
 
-    cmdOptions = ['run', '--name', 'python-reqs', '-v', `${bindPath}:/var/task:z` ];
-    
+    cmdOptions = [
+      'run',
+      '--name',
+      'python-reqs',
+      '-v',
+      `${bindPath}:/var/task:z`
+    ];
+
     if (options.proxy) {
-      cmdOptions.push('--env', `http_proxy=${options.proxy}`, '--env', `https_proxy=${options.proxy}`)
+      cmdOptions.push(
+        '--env',
+        `http_proxy=${options.proxy}`,
+        '--env',
+        `https_proxy=${options.proxy}`
+      );
     }
-    
+
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
@@ -281,21 +301,27 @@ function installRequirements(targetFolder, serverless, options) {
     cmdOptions.push(getStripCommand(options, preparedPath));
   }
 
-  executeCmdAsSpawnSync(cmd, cmdOptions, options);
+  try {
+    // execute the pip install (inside the container
+    executeCmdAsSpawnSync(cmd, cmdOptions, options);
 
-  if (options.dockerizePip) {
-    if (options.dockerRemoteHost) {
-      // copy the files back from the data volume
-      serverless.cli.log("Copying python libraries off docker container, ready for zipping")
-      cmdOptions = ['cp', 'python-reqs:/var/task/.', targetFolder] // volume create data-volume
-      executeCmdAsSpawnSync(cmd, cmdOptions, options)
+    if (options.dockerizePip) {
+      if (options.dockerRemoteHost) {
+        // copy the files back from the data volume
+        serverless.cli.log(
+          'Copying python libraries off docker container, ready for zipping'
+        );
+        cmdOptions = ['cp', 'python-reqs:/var/task/.', targetFolder]; // volume create data-volume
+        executeCmdAsSpawnSync(cmd, cmdOptions, options);
+      }
     }
-
-    // remove the container - not needed any more
-    serverless.cli.log("Removing container image")
-    cmdOptions = ['rm', 'python-reqs' ] // volume create data-volume
-    executeCmdAsSpawnSync(cmd, cmdOptions, options)
-
+  } finally {
+    if (options.dockerizePip) {
+      // clean up for next time.
+      serverless.cli.log('Removing container image');
+      cmdOptions = ['rm', 'python-reqs']; // remove data-volume
+      executeCmdAsSpawnSync(cmd, cmdOptions, options);
+    }
   }
 
   // If enabled slimming, delete files in slimPatterns
@@ -315,7 +341,9 @@ function executeCmdAsSpawnSync(cmd, cmdOptions, options) {
       if (options.dockerizePip) {
         throw new Error('docker not found! Please install it.');
       }
-      throw new Error(`${options.pythonBin} not found! Try the pythonBin option.`);
+      throw new Error(
+        `${options.pythonBin} not found! Try the pythonBin option.`
+      );
     }
     throw res.error;
   }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -78,15 +78,15 @@ function installRequirements(targetFolder, serverless, options) {
   if (options.pipCmdExtraArgs.indexOf('--cache-dir') > -1) {
     if (options.dockerizePip) {
       throw 'Error: You can not use --cache-dir with Docker any more, please\n' +
-      '         use the new option useDownloadCache instead.  Please see:\n' +
-      '         https://github.com/UnitedIncome/serverless-python-requirements#caching';
+        '         use the new option useDownloadCache instead.  Please see:\n' +
+        '         https://github.com/UnitedIncome/serverless-python-requirements#caching';
     } else {
       serverless.cli.log('==================================================');
       serverless.cli.log(
         'Warning: You are using a deprecated --cache-dir inside\n' +
-        '            your pipCmdExtraArgs which may not work properly, please use the\n' +
-        '            useDownloadCache option instead.  Please see: \n' +
-        '            https://github.com/UnitedIncome/serverless-python-requirements#caching'
+          '            your pipCmdExtraArgs which may not work properly, please use the\n' +
+          '            useDownloadCache option instead.  Please see: \n' +
+          '            https://github.com/UnitedIncome/serverless-python-requirements#caching'
       );
       serverless.cli.log('==================================================');
     }


### PR DESCRIPTION
Hi,

On our corporate network, we have a remote docker machine (defined in the DOCKER_HOST env var), rather than being able to spin up containers locally. This means that when you use Dockerizepip, it fails when trying to mount the volume (can't mount local filesystem to a remote docker server). So.. the fix is that instead of mounting the local folder, create a docker volume, copy the files into it, mount that to the container, do the pip install magic, then copy the files back off the container.

I've got this working, see this PR. I have run the tests and they pass, but I can't get the BATS tests to run on my Mac. so not quite there. 

I am willing to beef up the testing if it's required.. but first I'd like feedback that this PR is something that you're actually interested in. 

Let me know..

cheers!
Str3tch