### PR TITLE
Update pip.js

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -194,7 +194,7 @@ function installRequirements(targetFolder, serverless, options) {
       // Mount necessary ssh files to work with private repos
       dockerCmd.push(
         '-v',
-        `${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z`,
+        `${process.env.HOME}/.ssh/${options.keyFile || 'id_rsa'}:/root/.ssh/id_rsa:z`,
         '-v',
         `${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z`,
         '-v',


### PR DESCRIPTION
Add a `keyFile` option, so you could replace the default keyfile for one that is not `id_rds`

This change was made to make possible a work arround for https://github.com/UnitedIncome/serverless-python-requirements/issues/272 

But it may also be a interesting feature.