### PR TITLE
Don't zip requirements for non-Python runtimes

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -17,6 +17,11 @@ function addVendorHelper() {
   if (this.options.zip) {
     if (this.serverless.service.package.individually) {
       return BbPromise.resolve(this.targetFuncs)
+        .filter(func =>
+          (func.runtime || this.serverless.service.provider.runtime).match(
+            /^python.*/
+          )
+        )
         .map(f => {
           if (!get(f, 'package.include')) {
             set(f, ['package', 'include'], []);
@@ -63,6 +68,11 @@ function removeVendorHelper() {
   if (this.options.zip && this.options.cleanupZipHelper) {
     if (this.serverless.service.package.individually) {
       return BbPromise.resolve(this.targetFuncs)
+        .filter(func =>
+          (func.runtime || this.serverless.service.provider.runtime).match(
+            /^python.*/
+          )
+        )
         .map(f => {
           if (!get(f, 'module')) {
             set(f, ['module'], '.');
@@ -95,6 +105,11 @@ function packRequirements() {
   if (this.options.zip) {
     if (this.serverless.service.package.individually) {
       return BbPromise.resolve(this.targetFuncs)
+        .filter(func =>
+          (func.runtime || this.serverless.service.provider.runtime).match(
+            /^python.*/
+          )
+        )
         .map(f => {
           if (!get(f, 'module')) {
             set(f, ['module'], '.');


### PR DESCRIPTION
`serverless-python-requirements` tries to zip requirements for non-Python runtimes when `zip: true` and individual packaging is used. This PR skips the zipping step for functions that have runtimes that are not Python ones. A minimal example that reproduces this behaviour:

serverless.yml
```
service: min-example

provider:
  name: aws
  runtime: python3.6

package:
  individually: true

custom:
  pythonRequirements:
    zip: true

functions:
  example:
    handler: src/index.handler
    module: src

  non_python:
    handler: index.handler
    runtime: node10.x


plugins:
  - serverless-python-requirements
```

Directory structure
```
src
├ index.py
└ requirements.txt
index.js
serverless.yml
```

The contents of the files (except for serverless.yml, obviously) don't matter.

I ran into this issue when using `serverless-pyton-requirements` and `serverless-plugin-warmup`, which creates a `node` lambda which I barely have control over.