### PR TITLE
Add option to unchange permissions of cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ class ServerlessPythonRequirements {
         dockerBuildCmdExtraArgs: [],
         dockerRunCmdExtraArgs: [],
         dockerExtraFiles: [],
+        dockerRootless: false,
         useStaticCache: true,
         useDownloadCache: true,
         cacheLocation: false,

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -250,12 +250,14 @@ function installRequirements(targetFolder, serverless, options) {
       }
       // Install requirements with pip
       // Set the ownership of the current folder to user
-      pipCmds.push([
-        'chown',
-        '-R',
-        `${process.getuid()}:${process.getgid()}`,
-        '/var/task'
-      ]);
+      if (!options.dockerRootless) {
+        pipCmds.push([
+          'chown',
+          '-R',
+          `${process.getuid()}:${process.getgid()}`,
+          '/var/task'
+        ]);
+      }
     } else {
       // Use same user so --cache-dir works
       dockerCmd.push('-u', getDockerUid(bindPath));
@@ -266,7 +268,7 @@ function installRequirements(targetFolder, serverless, options) {
     }
 
     if (process.platform === 'linux') {
-      if (options.useDownloadCache) {
+      if (options.useDownloadCache && !options.dockerRootless) {
         // Set the ownership of the download cache dir back to user
         pipCmds.push([
           'chown',


### PR DESCRIPTION
I am using in Linux with docker-engine as rootless mode.

- https://docs.docker.com/engine/security/rootless/

Currently, `installRequirements()` run `chown` command to set same uid/gid from running docker container. 
But, It is not need on rootless-mode because container run in user namespace and keep local uid/gid.

This PR is to add option `dockerRootless` to not run chown command.
I think that it can fix iessues #459 and #421.

Note:
 - I confirmed to sucseed `sls package` command  in own project. But I could not check all what is exists other impacts.
- I cannot add fitly tests .