### PR TITLE
No longer sort generated requriements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,3 +553,4 @@ package:
 - [@bweigel](https://github.com/bweigel) - adding the `slimPatternsAppendDefaults` option & fixing per-function packaging when some functions don't have requirements & Porting tests from bats to js!
 - [@squaresurf](https://github.com/squaresurf) - adding usePoetry option
 - [@david-mk-lawrence](https://github.com/david-mk-lawrence) - added Lambda Layer support
+

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -368,7 +368,7 @@ function getRequirements(source) {
 /** create a filtered requirements.txt without anything from noDeploy
  *  then remove all comments and empty lines.  NOTE: In contrast to how
  *  this function used to work, it no longer re-orders requirements.txt
- *  contents to preserve ordering-related issues.  See: 
+ *  contents to preserve ordering-related issues.  See:
  *  https://pip.pypa.io/en/stable/reference/pip_install/#installation-order
  * @param {string} source requirements
  * @param {string} target requirements where results are written

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -366,12 +366,10 @@ function getRequirements(source) {
 }
 
 /** create a filtered requirements.txt without anything from noDeploy
- *  then remove all comments and empty lines, and sort the list which
- *  assist with matching the static cache.  The sorting will skip any
- *  lines starting with -- as those are typically ordered at the
- *  start of a file ( eg: --index-url / --extra-index-url ) or any
- *  lines that start with -f or -i,  Please see:
- * https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+ *  then remove all comments and empty lines.  NOTE: In contrast to how
+ *  this function used to work, it no longer re-orders requirements.txt
+ *  contents to preserve ordering-related issues.  See: 
+ *  https://pip.pypa.io/en/stable/reference/pip_install/#installation-order
  * @param {string} source requirements
  * @param {string} target requirements where results are written
  * @param {Object} options
@@ -379,32 +377,16 @@ function getRequirements(source) {
 function filterRequirementsFile(source, target, options) {
   const noDeploy = new Set(options.noDeploy || []);
   const requirements = getRequirements(source);
-  var prepend = [];
   const filteredRequirements = requirements.filter(req => {
     req = req.trim();
     if (req.startsWith('#')) {
       // Skip comments
-      return false;
-    } else if (
-      req.startsWith('--') ||
-      req.startsWith('-f') ||
-      req.startsWith('-i')
-    ) {
-      // If we have options (prefixed with --) keep them for later
-      prepend.push(req);
       return false;
     } else if (req === '') {
       return false;
     }
     return !noDeploy.has(req.split(/[=<> \t]/)[0].trim());
   });
-  filteredRequirements.sort(); // Sort remaining alphabetically
-  // Then prepend any options from above in the same order
-  for (let item of prepend.reverse()) {
-    if (item && item.length > 0) {
-      filteredRequirements.unshift(item);
-    }
-  }
   fse.writeFileSync(target, filteredRequirements.join('\n') + '\n');
 }
 


### PR DESCRIPTION
### Purpose
I removed the "feature" that sorts the contents of the requirements.txt file before running pip install

### Reasoning
This is a long-time coming.  This feature which I originally thought was quite novel was also met with a lot of problems after merging from the general public.  I added this feature when I added the ability for this plugin to cache the requirements locally to prevent unnecessary re-building of requirements when the requirements.txt file did not change.  At the time, I was managing roughly 5 different serverless codebases which uses the same dependencies but their requirements.txt files differed because of some dev/internal/local/nodeploy dependencies.  To solve this problem I cleansed and sorted the requirements.txt file.  Unfortunately, this inevitably had a LOT of issues because of edge cases I was not aware of when I first implemented it the biggest of which is that [pip resolves circular dependencies by having the first package taking priority](https://pip.pypa.io/en/stable/reference/pip_install/#installation-order).

### Result
Because of this, and this new knowledge I firmly believe we must preserve the order of the files inside the requirements.txt file, even at the risk of a bit less of a cache-hit.

### Related to and/or would have prevented:
#427
#294
#238