### PR TITLE
Mount the entire user SSH directory into build container

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ custom:
     dockerSsh: true
 ```
 
-The `dockerSsh` option will mount your `$HOME/.ssh/id_rsa` and `$HOME/.ssh/known_hosts` as a
+The `dockerSsh` option will mount your `$HOME/.ssh/` directory as a
 volume in the docker container. If your SSH key is password protected, you can use `ssh-agent`
 because `$SSH_AUTH_SOCK` is also mounted & the env var set.
 It is important that the host of your private repositories has already been added in your

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -491,6 +491,9 @@ function installRequirementsIfNeeded(
 
   // Skip requirements generation, if requirements file doesn't exist
   if (!requirementsFileExists(servicePath, options, fileName)) {
+    serverless.cli.log(
+      `Skipping generation of requirements: file ${fileName} not found`
+    );
     return false;
   }
 

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -204,14 +204,21 @@ function installRequirements(targetFolder, serverless, options) {
       // Mount necessary ssh files to work with private repos
       dockerCmd.push(
         '-v',
-        `${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z`,
-        '-v',
-        `${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z`,
+        `${process.env.HOME}/.ssh/:/root/.ssh/:z`,
         '-v',
         `${process.env.SSH_AUTH_SOCK}:/tmp/ssh_sock:z`,
         '-e',
         'SSH_AUTH_SOCK=/tmp/ssh_sock'
       );
+
+      // If the user has a SSH_CONFIG file, it won't have the correct permissions
+      // inside the docker container, and the ssh command will fail with
+      // > Bad owner or permissions on /root/.ssh/config
+      // However, if the we specify the SSH_CONFIG file with -F explicitly,
+      // ssh does not check the ownership of the file.
+      if (fse.existsSync(`${process.env.HOME}/.ssh/config`)) {
+        dockerCmd.push('-e', 'GIT_SSH_COMMAND=ssh -F /root/.ssh/config');
+      }
     }
 
     // If we want a download cache...

--- a/tests/base/requirements-w-git-ssh.txt
+++ b/tests/base/requirements-w-git-ssh.txt
@@ -1,0 +1,3 @@
+flask
+bottle
+git+ssh://git@github.com/boto/boto3.git#egg=boto3

--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -10,6 +10,7 @@ custom:
   pythonRequirements:
     zip: ${opt:zip, self:custom.defaults.zip}
     dockerizePip: ${opt:dockerizePip, self:custom.defaults.dockerizePip}
+    dockerSsh: ${opt:dockerSsh, self:custom.defaults.dockerSsh}
     slim: ${opt:slim, self:custom.defaults.slim}
     slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
     slimPatternsAppendDefaults: ${opt:slimPatternsAppendDefaults, self:custom.defaults.slimPatternsAppendDefaults}
@@ -24,6 +25,7 @@ custom:
     slimPatternsAppendDefaults: true
     zip: false
     dockerizePip: false
+    dockerSsh: false
     individually: false
     useStaticCache: true
     useDownloadCache: true
@@ -49,5 +51,3 @@ functions:
     package:
       include:
         - 'fn2/**'
-
-


### PR DESCRIPTION
This enables the user to use an key file format (RSA, ED25519, ...).
Additionally, it allows more complex workflows (such as different SSH keys for
specfic sites, such as Github or Bitbucket), since the .ssh/config
file is also mounted into the container.

Fixes https://github.com/UnitedIncome/serverless-python-requirements/issues/488