### PR TITLE
Fix error git clone failed with error code 128 - Windows

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -212,6 +212,8 @@ function installRequirements(targetFolder, serverless, options) {
         '-e',
         'SSH_AUTH_SOCK=/tmp/ssh_sock'
       );
+      chmod_cmd = ['chmod', '600', '/root/.ssh/id_rsa'];
+      pipCmds.unshift(chmod_cmd);
     }
 
     // If we want a download cache...


### PR DESCRIPTION
Docker for Windows has some issues with the permissions when mounting files in containers. 

https://github.com/docker/for-win/issues/2042