### PR TITLE
Support recursively adding files to serverless package

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,17 @@ zipinfo .serverless/xxx.zip
 
 If you can't see the library, you might need to adjust your package include/exclude configuration in `serverless.yml`.
 
+If you would like to recursively include a directory and all of its contents, 
+prepend `-r ` to the file list member:
+
+```yaml
+custom:
+  pythonRequirements:
+    dockerExtraFiles:
+      - -r /path/to/additional/dependencies/
+```
+
+
 ## Optimising packaging time
 
 If you wish to exclude most of the files in your project, and only include the source files of your lambdas and their dependencies you may well use an approach like this:

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -262,7 +262,13 @@ function installRequirements(targetFolder, serverless, options) {
     }
 
     for (let path of options.dockerExtraFiles) {
-      pipCmds.push(['cp', path, '/var/task/']);
+      let cmd = ['cp', path, '/var/task/'];
+      // Copy recursively if -r option was specified
+      if (path.startsWith('-r ')) {
+        path = path.split(' ')[1];
+        cmd = ['cp', '-r', path, '/var/task/']
+      }
+      pipCmds.push(cmd);
     }
 
     if (process.platform === 'linux') {


### PR DESCRIPTION
I was looking for this functionality earlier today (see #542), but it didn't seem to exist, so modified the parsing of `dockerExtraFiles` to support it. Maybe it's useful to others?