### PR TITLE
Remove config validation warnings: "unrecognized property 'module'"

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,12 @@ class ServerlessPythonRequirements {
     this.servicePath = this.serverless.config.servicePath;
     this.warningLogged = false;
 
+    this.serverless.configSchemaHandler.defineFunctionProperties('aws', {
+      properties: {
+        module: {type: 'string'},
+      },
+    });
+
     this.commands = {
       requirements: {
         usage: 'Serverless plugin to bundle Python packages',


### PR DESCRIPTION
Also brought up here: https://github.com/serverless/serverless/issues/8423

Function Schema Validation is executed by default with the update from Serverless to 2.7.0. This picks up validation errors for the "module" keyword which is used in this plugin.

In Serverless 2.10.0, they introduced the "defineFunctionProperties" function https://github.com/serverless/serverless/pull/8462 This can be used to extend the aws function definition to include new keywords. 

I believe adding the following code to the constructer of the plugin would eliminate these warnings but it would cause errors with anyone using a version of Serverless before 2.10.0.