### PR TITLE
Fix rootless dockerization

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -247,7 +247,10 @@ function installRequirements(targetFolder, serverless, options) {
     let rootlessDocker = false;
     if (process.platform === 'linux') {
       // Check if Docker is running rootless
-      const res = spawnSync('docker', ['info', '--format={{json .SecurityOptions}}']);
+      const res = spawnSync('docker', [
+        'info',
+        '--format={{json .SecurityOptions}}'
+      ]);
       if (res.error) {
         throw res.error;
       }
@@ -255,7 +258,7 @@ function installRequirements(targetFolder, serverless, options) {
         throw new Error(`STDOUT: ${res.stdout}\n\nSTDERR: ${res.stderr}`);
       }
       // res.stdout should contain JSON Array, which contains "name=rootless" if running rootless
-      rootlessDocker = JSON.parse(res.stdout).indexOf("name=rootless") > -1;
+      rootlessDocker = JSON.parse(res.stdout).indexOf('name=rootless') > -1;
     }
 
     if (process.platform === 'linux') {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -244,20 +244,36 @@ function installRequirements(targetFolder, serverless, options) {
       });
     }
 
+    let rootlessDocker = false;
     if (process.platform === 'linux') {
-      // Use same user so requirements folder is not root and so --cache-dir works
-      if (options.useDownloadCache) {
-        // Set the ownership of the download cache dir to root
-        pipCmds.unshift(['chown', '-R', '0:0', dockerDownloadCacheDir]);
+      // Check if Docker is running rootless
+      const res = spawnSync('docker', ['info', '--format={{json .SecurityOptions}}']);
+      if (res.error) {
+        throw res.error;
       }
-      // Install requirements with pip
-      // Set the ownership of the current folder to user
-      pipCmds.push([
-        'chown',
-        '-R',
-        `${process.getuid()}:${process.getgid()}`,
-        '/var/task'
-      ]);
+      if (res.status !== 0) {
+        throw new Error(`STDOUT: ${res.stdout}\n\nSTDERR: ${res.stderr}`);
+      }
+      // res.stdout should contain JSON Array, which contains "name=rootless" if running rootless
+      rootlessDocker = JSON.parse(res.stdout).indexOf("name=rootless") > -1;
+    }
+
+    if (process.platform === 'linux') {
+      if (!rootlessDocker) {
+        // Use same user so requirements folder is not root and so --cache-dir works
+        if (options.useDownloadCache) {
+          // Set the ownership of the download cache dir to root
+          pipCmds.unshift(['chown', '-R', '0:0', dockerDownloadCacheDir]);
+        }
+        // Install requirements with pip
+        // Set the ownership of the current folder to user
+        pipCmds.push([
+          'chown',
+          '-R',
+          `${process.getuid()}:${process.getgid()}`,
+          '/var/task'
+        ]);
+      }
     } else {
       // Use same user so --cache-dir works
       dockerCmd.push('-u', getDockerUid(bindPath));
@@ -267,7 +283,7 @@ function installRequirements(targetFolder, serverless, options) {
       pipCmds.push(['cp', path, '/var/task/']);
     }
 
-    if (process.platform === 'linux') {
+    if (process.platform === 'linux' && !rootlessDocker) {
       if (options.useDownloadCache) {
         // Set the ownership of the download cache dir back to user
         pipCmds.push([


### PR DESCRIPTION
[Rootless Docker](https://docs.docker.com/engine/security/rootless/)
provides enhanced security for Linux users, but maps the uids and gids
in ways not compatible with what this module was doing.  If rootless
Docker is detected, skip the unnecessary `chown` commands.

(fixes #589)