### PR TITLE
Access the specified function by name from the map of functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class ServerlessPythonRequirements {
   get targetFuncs() {
     let inputOpt = this.serverless.processedInput.options;
     return inputOpt.function
-      ? [inputOpt.functionObj]
+      ? [this.serverless.service.functions[inputOpt.function]]
       : values(this.serverless.service.functions);
   }
 


### PR DESCRIPTION
There is no attribute called functionObj
on the processedInput.options object.

#605