### PR TITLE
docs: Add a warning about individual packaging with Poetry/Pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ custom:
 
 ### Per-function requirements
 
+**Note: this feature does not work with Pipenv/Poetry, it requires `requirements.txt`
+files for your Python modules.**
+
 If you have different python functions, with different sets of requirements, you can avoid
 including all the unecessary dependencies of your functions by using the following structure:
 


### PR DESCRIPTION
This pull request adds a warning regarding the lack of support of the individual packaging feature for modules that use Pipenv or Poetry.

#341 could take time before being merged and support for Poetry could arrive even later, in the meanwhile we should at least warn users about it.

Relates to https://github.com/UnitedIncome/serverless-python-requirements/issues/268.