### PR TITLE
Enhance poetry related logging and add new flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ custom:
     usePoetry: false
 ```
 
+Be aware that if no `poetry.lock` file is present, a new one will be generated on the fly. To help having predictable builds,
+you can set the `requirePoetryLockFile` flag to true to throw an error when `poetry.lock` is missing.
+
+```yaml
+custom:
+  pythonRequirements:
+    requirePoetryLockFile: false
+```
+
 ### Poetry with git dependencies
 
 Poetry by default generates the exported requirements.txt file with `-e` and that breaks pip with `-t` parameter

--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ class ServerlessPythonRequirements {
         staticCacheMaxVersions: 0,
         pipCmdExtraArgs: [],
         noDeploy: [],
-        vendor: ''
+        vendor: '',
+        requirePoetryLockFile: false
       },
       (this.serverless.service.custom &&
         this.serverless.service.custom.pythonRequirements) ||

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -12,7 +12,21 @@ function pyprojectTomlToRequirements() {
     return;
   }
 
-  this.serverless.cli.log('Generating requirements.txt from pyproject.toml...');
+  const lockFileRes = spawnSync("test", ["-f", "poetry.lock"])
+  if (lockFileRes.status !== 0) {
+    this.serverless.cli.log('Generating requirements.txt from poetry.lock...');
+  } else {
+    if (this.options.requirePoetryLockFile) {
+      throw new Error(
+        "poetry.lock file not found - set requirePoetryLockFile to false to "
+        + "disable this error"
+      );
+    }
+    this.serverless.cli.log(
+      'Generating poetry.lock and requirements.txt from pyproject.toml...'
+    );
+  }
+
 
   const res = spawnSync(
     'poetry',


### PR DESCRIPTION
* Distinct logging whether the requirements.txt file is generated from
  poetry.lock vs pyproject.toml.
* New boolean flag: requirePoetryLockFile - When set to true, fail the build
  when poetry.lock is missing. This helps with creating reproducible
  builds where you want to have a fixed poetry.lock file instead of one
  generated on the fly.

Note that there are no tests. With some guidance I am willing to add some.