### PR TITLE
feat: Introduce schema validation for `module` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,18 @@ class ServerlessPythonRequirements {
     this.serverless = serverless;
     this.servicePath = this.serverless.config.servicePath;
     this.warningLogged = false;
-
+    if (
+      this.serverless.configSchemaHandler &&
+      this.serverless.configSchemaHandler.defineFunctionProperties
+    ) {
+      this.serverless.configSchemaHandler.defineFunctionProperties('aws', {
+        properties: {
+          module: {
+            type: 'string',
+          },
+        },
+      });
+    }
     this.commands = {
       requirements: {
         commands: {


### PR DESCRIPTION
defines the module property to remove the validation error in serverless 2.0+ 

ref: https://github.com/serverless/serverless-python-requirements/pull/575