### PR TITLE
Vendor option supports common code inclusion when packaging individually

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -544,6 +544,17 @@ function installRequirementsIfNeeded(
     options
   );
 
+    // Copy vendor libraries to requirements folder
+    // Do this before checking for cached libraries to support multiple packaged individually
+    // lambdas that need need to include common code. This source would change frequently and 
+    // would not benefit from the caching.
+    if (options.vendor) {
+      copyVendors(options.vendor, workingReqsFolder, serverless);
+    }
+    if (funcOptions.vendor) {
+      copyVendors(funcOptions.vendor, workingReqsFolder, serverless);
+    }
+
   // Check if our static cache is present and is valid
   if (fse.existsSync(workingReqsFolder)) {
     if (
@@ -574,14 +585,6 @@ function installRequirementsIfNeeded(
 
   // Then install our requirements from this folder
   installRequirements(workingReqsFolder, serverless, options);
-
-  // Copy vendor libraries to requirements folder
-  if (options.vendor) {
-    copyVendors(options.vendor, workingReqsFolder, serverless);
-  }
-  if (funcOptions.vendor) {
-    copyVendors(funcOptions.vendor, workingReqsFolder, serverless);
-  }
 
   // Then touch our ".completed_requirements" file so we know we can use this for static cache
   if (options.useStaticCache) {


### PR DESCRIPTION
Vendor option can now be used for common code inclusion when lambdas are being packaged individually. This prevents the step of copying vendor from being skipped because of caching. Enabling normal development workflow.

This will help with the following ticket where developers are already using the vendor option for common code inclusion but need to disable caching: https://github.com/serverless/serverless-python-requirements/issues/435
