### PR TITLE
fix: Ensure cast `toString` before `trim` on buffer

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -103,12 +103,12 @@ async function tryBindPath(bindPath, testFile, pluginInstance) {
     const ps = await dockerCommand(options, pluginInstance);
     if (debug) {
       if (log) {
-        log.debug(ps.stdoutBuffer.trim());
+        log.debug(ps.stdoutBuffer.toString().trim());
       } else {
-        serverless.cli.log(ps.stdoutBuffer.trim());
+        serverless.cli.log(ps.stdoutBuffer.toString().trim());
       }
     }
-    return ps.stdoutBuffer.trim() === `/test/${testFile}`;
+    return ps.stdoutBuffer.toString().trim() === `/test/${testFile}`;
   } catch (err) {
     if (debug) {
       if (log) {
@@ -197,7 +197,7 @@ async function getDockerUid(bindPath, pluginInstance) {
     '/bin/sh',
   ];
   const ps = await dockerCommand(options, pluginInstance);
-  return ps.stdoutBuffer.trim();
+  return ps.stdoutBuffer.toString().trim();
 }
 
 module.exports = { buildImage, getBindPath, getDockerUid };


### PR DESCRIPTION
Ensure proper cast to string before `trim` call as reported in: https://github.com/serverless/serverless-python-requirements/pull/648#issuecomment-984840164