### PR TITLE
fix: Address unknown path format error in `wsl2`

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -130,7 +130,7 @@ async function tryBindPath(bindPath, testFile, pluginInstance) {
  */
 async function getBindPath(servicePath, pluginInstance) {
   // Determine bind path
-  let isWsl1 = isWsl && !os.release().includes('microsoft-standard')
+  let isWsl1 = isWsl && !os.release().includes('microsoft-standard');
   if (process.platform !== 'win32' && !isWsl1) {
     return servicePath;
   }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -2,6 +2,7 @@ const spawn = require('child-process-ext/spawn');
 const isWsl = require('is-wsl');
 const fse = require('fs-extra');
 const path = require('path');
+const os = require('os');
 
 /**
  * Helper function to run a docker command
@@ -129,7 +130,8 @@ async function tryBindPath(bindPath, testFile, pluginInstance) {
  */
 async function getBindPath(servicePath, pluginInstance) {
   // Determine bind path
-  if (process.platform !== 'win32' && !isWsl) {
+  let isWsl1 = isWsl && !os.release().includes('microsoft-standard')
+  if (process.platform !== 'win32' && !isWsl1) {
     return servicePath;
   }
 


### PR DESCRIPTION
This change solves the problem [#371](https://github.com/serverless/serverless-python-requirements/issues/371) that is occurring in wsl2.
In order to make wsl2 work as well as linux, the wsl decision was changed so that it only applies to wsl1.
