### PR TITLE
fix: fix stdio and tons of windows issues

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -400,7 +400,7 @@ async function installRequirements(targetFolder, pluginInstance) {
 
     for (const [cmd, ...args] of mainCmds) {
       try {
-        await spawn(cmd, args);
+        await spawn(cmd, args, spawnArgs);
       } catch (e) {
         if (
           e.stderrBuffer &&


### PR DESCRIPTION
This PR adds back stdio for output priting and the `shell: true` to spawn method so it can properly run in Windows.
This was broken in https://github.com/serverless/serverless-python-requirements/commit/937fa564bf12fcb043678a0b48064bc60cbd2ea2