### PR TITLE
bugfix: ENOENT error when packaging individually while none of the functions have a requirements file

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -600,11 +600,6 @@ async function installRequirementsIfNeeded(
 
   await pyprojectTomlToRequirements(modulePath, pluginInstance);
 
-  // Skip requirements generation, if requirements file doesn't exist
-  if (!requirementsFileExists(servicePath, options, fileName)) {
-    return false;
-  }
-
   let requirementsTxtDirectory;
   // Copy our requirements to another path in .serverless (incase of individually packaged)
   if (modulePath && modulePath !== '.') {
@@ -617,6 +612,21 @@ async function installRequirementsIfNeeded(
     requirementsTxtDirectory = path.join(servicePath, '.serverless');
   }
   fse.ensureDirSync(requirementsTxtDirectory);
+
+  // Skip requirements generation, if requirements file doesn't exist
+  if (!requirementsFileExists(servicePath, options, fileName)) {
+    // generate an empty requirements folder to prevent missing dir errors
+    const workingReqsFolder = getRequirementsWorkingPath(
+      '',
+      requirementsTxtDirectory,
+      options,
+      serverless
+    );
+    fse.ensureDirSync(workingReqsFolder);
+
+    return false;
+  }
+
   const slsReqsTxt = path.join(requirementsTxtDirectory, 'requirements.txt');
 
   generateRequirementsFile(fileName, slsReqsTxt, pluginInstance);


### PR DESCRIPTION
This addresses issue https://github.com/serverless/serverless-python-requirements/issues/397

In 2019 @ComfyDust [did an investigation](https://github.com/serverless/serverless-python-requirements/issues/397#issuecomment-533755933) into this and pinpointed it to the `pip.js` file, with a workaround that you can create an empty `requirements.txt` file in each function folder.

As of 2022, the workaround is creating a `requirements.txt` file in a _single_ function folder, which creates the requirements directory and prevents an ENOENT.

This PR ensures that the function's requirements parent directory is created regardless of whether a requirements file exists. 

In my testing this did not increase deployment times at all, and lets packaging "individually" work if no requirements files are in any folder.

