### PR TITLE
fix: debug logs for command execution failure

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -10,10 +10,19 @@ const os = require('os');
  * @return {Object}
  */
 async function dockerCommand(options, pluginInstance) {
+  const { serverless, log } = pluginInstance;
+  const debug = process.env.SLS_DEBUG;  
   const cmd = 'docker';
   try {
     return await spawn(cmd, options, { encoding: 'utf-8' });
   } catch (e) {
+    if (debug) {
+      if (log) {
+        log.debug(e);
+      } else {
+        serverless.cli.log(e);
+      }
+    }
     if (
       e.stderrBuffer &&
       e.stderrBuffer.toString().includes('command not found')


### PR DESCRIPTION
If docker command execution fails due to a bad `Dockerfile` the error will always be `docker not found`. This will allow to output the actual exception instead.