### PR TITLE
Fix zip file name for nested modules

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -120,9 +120,10 @@ async function injectAllRequirements(funcArtifact) {
             const artifact = func.package
               ? func.package.artifact
               : funcArtifact;
+            const moduleName = func.module.replace('/', '-');
             const newArtifact = path.join(
               '.serverless',
-              `${func.module}-${func.name}.zip`
+              `${moduleName}-${func.name}.zip`
             );
             func.package.artifact = newArtifact;
             return moveModuleUp(artifact, newArtifact, func.module).then(


### PR DESCRIPTION
If `module` is set to something like `src/functions` the plugin fails as the package zip filename has a '/' within it