### PR TITLE
feat: Switch to official AWS docker images by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,9 @@ class ServerlessPythonRequirements {
       );
     } else if (!options.dockerFile) {
       // If no dockerFile is provided, use default image
-      const defaultImage = `public.ecr.aws/sam/build-${this.serverless.service.provider.runtime}`;
+      const architecture =
+        this.serverless.service.provider.architecture || 'x86_64';
+      const defaultImage = `public.ecr.aws/sam/build-${this.serverless.service.provider.runtime}:latest-${architecture}`;
       options.dockerImage = options.dockerImage || defaultImage;
     }
     if (options.layer) {

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class ServerlessPythonRequirements {
       );
     } else if (!options.dockerFile) {
       // If no dockerFile is provided, use default image
-      const defaultImage = `lambci/lambda:build-${this.serverless.service.provider.runtime}`;
+      const defaultImage = `public.ecr.aws/sam/build-${this.serverless.service.provider.runtime}`;
       options.dockerImage = options.dockerImage || defaultImage;
     }
     if (options.layer) {


### PR DESCRIPTION
BREAKING CHANGE: Switches to official AWS docker images from previous `lambci` images that did not support Python 3.9

Switch to official images as defaults for packaging with Docker. Please note that it's a breaking change and will be released as a part of next major version of the plugin. 

Closes: #647 