### PR TITLE
feat: Introduce `requirePoetryLockFile` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ custom:
     usePoetry: false
 ```
 
+Be aware that if no `poetry.lock` file is present, a new one will be generated on the fly. To help having predictable builds,
+you can set the `requirePoetryLockFile` flag to true to throw an error when `poetry.lock` is missing.
+
+```yaml
+custom:
+  pythonRequirements:
+    requirePoetryLockFile: false
+```
+
 ### Poetry with git dependencies
 
 Poetry by default generates the exported requirements.txt file with `-e` and that breaks pip with `-t` parameter

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ class ServerlessPythonRequirements {
         pipCmdExtraArgs: [],
         noDeploy: [],
         vendor: '',
+        requirePoetryLockFile: false,
       },
       (this.serverless.service.custom &&
         this.serverless.service.custom.pythonRequirements) ||

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -21,12 +21,28 @@ async function pyprojectTomlToRequirements(modulePath, pluginInstance) {
     generateRequirementsProgress = progress.get(
       'python-generate-requirements-toml'
     );
-    generateRequirementsProgress.update(
-      'Generating requirements.txt from "pyproject.toml"'
-    );
-    log.info('Generating requirements.txt from "pyproject.toml"');
+  }
+
+  const emitMsg = (msg) => {
+    if (generateRequirementsProgress) {
+      generateRequirementsProgress.update(msg);
+      log.info(msg);
+    } else {
+      serverless.cli.log(msg);
+    }
+  };
+
+  if (fs.existsSync('poetry.lock')) {
+    emitMsg('Generating requirements.txt from poetry.lock');
   } else {
-    serverless.cli.log('Generating requirements.txt from pyproject.toml...');
+    if (options.requirePoetryLockFile) {
+      throw new serverless.classes.Error(
+        'poetry.lock file not found - set requirePoetryLockFile to false to ' +
+          'disable this error',
+        'MISSING_REQUIRED_POETRY_LOCK'
+      );
+    }
+    emitMsg('Generating poetry.lock and requirements.txt from pyproject.toml');
   }
 
   try {

--- a/test.js
+++ b/test.js
@@ -1634,3 +1634,23 @@ test('py3.7 can ignore functions defined with `image`', async (t) => {
 
   t.end();
 });
+
+test('poetry py3.7 fails packaging if poetry.lock is missing and flag requirePoetryLockFile is set to true', async (t) => {
+  copySync('tests/poetry', 'tests/base with a space');
+  process.chdir('tests/base with a space');
+  removeSync('poetry.lock');
+
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  const stdout = sls(['package'], {
+    env: { requirePoetryLockFile: 'true', slim: 'true' },
+    noThrow: true,
+  });
+  t.true(
+    stdout.includes(
+      'poetry.lock file not found - set requirePoetryLockFile to false to disable this error'
+    ),
+    'flag works and error is properly reported'
+  );
+  t.end();
+});

--- a/tests/poetry/serverless.yml
+++ b/tests/poetry/serverless.yml
@@ -13,6 +13,7 @@ custom:
     slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
     slimPatternsAppendDefaults: ${env:slimPatternsAppendDefaults, self:custom.defaults.slimPatternsAppendDefaults}
     dockerizePip: ${env:dockerizePip, self:custom.defaults.dockerizePip}
+    requirePoetryLockFile: ${env:requirePoetryLockFile, false}
   defaults:
     zip: false
     slimPatterns: false


### PR DESCRIPTION
* Distinct logging whether the requirements.txt file is generated from poetry.lock vs pyproject.toml.
* New boolean flag: requirePoetryLockFile - When set to true, fail the build when poetry.lock is missing. This helps with creating reproducible builds where you want to have a fixed poetry.lock file instead of one generated on the fly.

Follow up to https://github.com/serverless/serverless-python-requirements/pull/639