### PR TITLE
test: Remove tests against python2.7

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,9 +13,6 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -30,10 +27,10 @@ jobs:
           key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -64,9 +61,6 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js 14: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -81,10 +75,10 @@ jobs:
           key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -115,9 +109,6 @@ jobs:
   linuxNode12:
     name: '[Linux] Node.js v12: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -132,10 +123,10 @@ jobs:
           key: npm-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v12-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,9 +13,6 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js v14: Lint, Eventual Commitlint, Eventual Changelog, Formatting & Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -43,10 +40,10 @@ jobs:
             npm-v14-${{ runner.os }}-${{ github.ref }}-
             npm-v14-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -91,9 +88,6 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -110,10 +104,10 @@ jobs:
             npm-v14-${{ runner.os }}-${{ github.ref }}-
             npm-v14-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -144,9 +138,6 @@ jobs:
   linuxNode12:
     name: '[Linux] Node.js v12: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -163,10 +154,10 @@ jobs:
             npm-v12-${{ runner.os }}-${{ github.ref }}-
             npm-v12-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/test.js
+++ b/test.js
@@ -164,10 +164,6 @@ const getPythonBin = (version) => {
   return bin;
 };
 
-const hasPython = (version) => {
-  return Boolean(availablePythons[String(version)]);
-};
-
 const listZipFiles = async function (filename) {
   const file = await readFile(filename);
   const zip = await new JSZip().loadAsync(file);
@@ -227,54 +223,42 @@ test(
   { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'default pythonBin can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('default pythonBin can package flask with default options', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py3.7 packages have the same hash',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const fileHash = sha256File('.serverless/sls-py-req-test.zip');
-    sls(['package'], { env: {} });
-    t.equal(
-      sha256File('.serverless/sls-py-req-test.zip'),
-      fileHash,
-      'packages have the same hash'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 packages have the same hash', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const fileHash = sha256File('.serverless/sls-py-req-test.zip');
+  sls(['package'], { env: {} });
+  t.equal(
+    sha256File('.serverless/sls-py-req-test.zip'),
+    fileHash,
+    'packages have the same hash'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
 test(
   'py3.7 can package flask with hashes',
@@ -292,147 +276,119 @@ test(
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
     t.end();
   },
-  { skip: !hasPython(3) || brokenOn('win32') }
+  { skip: brokenOn('win32') }
 );
 
-test(
-  'py3.7 can package flask with nested',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        fileName: 'requirements-w-nested.txt',
-        pythonBin: getPythonBin(3),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with nested', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      fileName: 'requirements-w-nested.txt',
+      pythonBin: getPythonBin(3),
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  "py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: { pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test("py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: { pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'py3.7 can package boto3 with editable',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        fileName: 'requirements-w-editable.txt',
-        pythonBin: getPythonBin(3),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.true(
-      zipfiles.includes(`botocore${sep}__init__.py`),
-      'botocore is packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package boto3 with editable', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      fileName: 'requirements-w-editable.txt',
+      pythonBin: getPythonBin(3),
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.true(
+    zipfiles.includes(`botocore${sep}__init__.py`),
+    'botocore is packaged'
+  );
+  t.end();
+});
 
 test(
   'py3.7 can package flask with dockerizePip option',
@@ -446,7 +402,7 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -470,7 +426,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -495,7 +451,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -527,7 +483,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -561,603 +517,245 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py2.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.false(
+    zipfiles.includes(`pytest${sep}__init__.py`),
+    'dev-package pytest is NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', slim: 'true', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', zip: 'true', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/pipenv');
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('pipenv py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  "py2.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test("pipenv py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        zip: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('non build pyproject.toml uses requirements.txt', async (t) => {
+  process.chdir('tests/non_build_pyproject');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip & slim & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        zip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('non poetry pyproject.toml without requirements.txt packages handler only', async (t) => {
+  process.chdir('tests/non_poetry_pyproject');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`handler.py`), 'handler is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('poetry py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are NOT packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('poetry py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
+test('poetry py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/poetry');
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.false(
-      zipfiles.includes(`pytest${sep}__init__.py`),
-      'dev-package pytest is NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('poetry py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test("poetry py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/pipenv');
+test('py3.7 can package flask with zip option and no explicit include', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl(['-p', '-i.bak', '-e', 's/include://', 'serverless.yml']);
+  perl(['-p', '-i.bak', '-e', 's/^.*handler.py.*$//', 'serverless.yml']);
+  sls(['package'], { env: { zip: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'pipenv py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  "pipenv py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'non build pyproject.toml uses requirements.txt',
-  async (t) => {
-    process.chdir('tests/non_build_pyproject');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'non poetry pyproject.toml without requirements.txt packages handler only',
-  async (t) => {
-    process.chdir('tests/non_poetry_pyproject');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`handler.py`), 'handler is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/poetry');
-
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
-
-test(
-  "poetry py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package flask with zip option and no explicit include',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl(['-p', '-i.bak', '-e', 's/include://', 'serverless.yml']);
-    perl(['-p', '-i.bak', '-e', 's/^.*handler.py.*$//', 'serverless.yml']);
-    sls(['package'], { env: { zip: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package lambda-decorators using vendor option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { vendor: './vendor' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.true(
-      zipfiles.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package lambda-decorators using vendor option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { vendor: './vendor' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.true(
+    zipfiles.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged'
+  );
+  t.end();
+});
 
 test(
   "Don't nuke execute perms",
@@ -1204,24 +802,20 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.7) }
+  { skip: process.platform === 'win32' }
 );
 
-test(
-  'py3.7 can package flask in a project with a space in it',
-  async (t) => {
-    copySync('tests/base', 'tests/base with a space');
-    process.chdir('tests/base with a space');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask in a project with a space in it', async (t) => {
+  copySync('tests/base', 'tests/base with a space');
+  process.chdir('tests/base with a space');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
 test(
   'py3.7 can package flask in a project with a space in it with docker',
@@ -1236,103 +830,82 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 supports custom file name with fileName option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    writeFileSync('puck', 'requests');
-    npm(['i', path]);
-    sls(['package'], { env: { fileName: 'puck' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes(`requests${sep}__init__.py`),
-      'requests is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged'
-    );
-    t.false(
-      zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 supports custom file name with fileName option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  writeFileSync('puck', 'requests');
+  npm(['i', path]);
+  sls(['package'], { env: { fileName: 'puck' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes(`requests${sep}__init__.py`),
+    'requests is packaged'
+  );
+  t.false(zipfiles.includes(`flask${sep}__init__.py`), 'flask is NOT packaged');
+  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.end();
+});
 
-test(
-  "py3.7 doesn't package bottle with zip option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.false(
-      zippedReqs.includes(`bottle.py`),
-      'bottle is NOT packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test("py3.7 doesn't package bottle with zip option", async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  const zippedReqs = await listRequirementsZipFiles(
+    '.serverless/sls-py-req-test.zip'
+  );
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.true(
+    zippedReqs.includes(`flask/__init__.py`),
+    'flask is packaged in the .requirements.zip file'
+  );
+  t.false(
+    zippedReqs.includes(`bottle.py`),
+    'bottle is NOT packaged in the .requirements.zip file'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options', async (t) => {
+  process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
 test(
   'py3.7 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
@@ -1361,645 +934,366 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py2.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        slim: 'true',
-        slimPatternsAppendDefaults: 'false',
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(2.7) || brokenOn('win32') }
-);
+test('pipenv py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option', async (t) => {
+  process.chdir('tests/pipenv');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        dockerizePip: 'true',
-        runtime: 'python2.7',
-        slim: 'true',
-        slimPatternsAppendDefaults: 'false',
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2.7) || brokenOn('win32') }
-);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('poetry py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option', async (t) => {
+  process.chdir('tests/poetry');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'poetry py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('poetry py3.7 can package flask with package individually option', async (t) => {
+  process.chdir('tests/poetry_individually');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles(
+    '.serverless/module1-sls-py-req-test-dev-hello.zip'
+  );
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'poetry py3.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/poetry_individually');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('py3.7 can package flask with package individually option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.false(
+    zipfiles_hello.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
 
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles(
-      '.serverless/module1-sls-py-req-test-dev-hello.zip'
-    );
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.false(
+    zipfiles_hello2.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
 
-test(
-  'py3.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.false(
-      zipfiles_hello.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.false(
+    zipfiles_hello3.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello3'
+  );
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.false(
-      zipfiles_hello2.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.false(
+    zipfiles_hello4.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.false(
-      zipfiles_hello3.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello3'
-    );
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
+  t.end();
+});
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.false(
-      zipfiles_hello4.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
+test('py3.7 can package flask with package individually & slim option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true', slim: 'true' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged in function hello'
+  );
+  t.deepEqual(
+    zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged in function hello2'
+  );
+  t.deepEqual(
+    zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
 
-test(
-  'py3.7 can package flask with package individually & slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', slim: 'true' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.deepEqual(
-      zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged in function hello3'
+  );
+  t.deepEqual(
+    zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.deepEqual(
-      zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
+  t.deepEqual(
+    zipfiles_hello4.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello4'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.deepEqual(
-      zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
+  t.end();
+});
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-    t.deepEqual(
-      zipfiles_hello4.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello4'
-    );
+test('py3.7 can package only requirements of module', async (t) => {
+  process.chdir('tests/individually');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles_hello = await listZipFiles(
+    '.serverless/module1-sls-py-req-test-indiv-dev-hello1.zip'
+  );
+  t.true(
+    zipfiles_hello.includes('handler1.py'),
+    'handler1.py is packaged at root level in function hello1'
+  );
+  t.false(
+    zipfiles_hello.includes('handler2.py'),
+    'handler2.py is NOT packaged at root level in function hello1'
+  );
+  t.true(
+    zipfiles_hello.includes(`pyaml${sep}__init__.py`),
+    'pyaml is packaged in function hello1'
+  );
+  t.true(
+    zipfiles_hello.includes(`boto3${sep}__init__.py`),
+    'boto3 is packaged in function hello1'
+  );
+  t.false(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello1'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles(
+    '.serverless/module2-sls-py-req-test-indiv-dev-hello2.zip'
+  );
+  t.true(
+    zipfiles_hello2.includes('handler2.py'),
+    'handler2.py is packaged at root level in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes('handler1.py'),
+    'handler1.py is NOT packaged at root level in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`pyaml${sep}__init__.py`),
+    'pyaml is NOT packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`boto3${sep}__init__.py`),
+    'boto3 is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
 
-test(
-  'py2.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', runtime: 'python2.7' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
+  t.end();
+});
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
+test('py3.7 can package lambda-decorators using vendor and invidiually option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true', vendor: './vendor' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged at root level in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged at root level in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged at root level in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello3'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py2.7 can package flask with package individually & slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { individually: 'true', runtime: 'python2.7', slim: 'true' },
-    });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.deepEqual(
-      zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.deepEqual(
-      zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.deepEqual(
-      zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py2.7 can ignore functions defined with `image`',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', runtime: 'python2.7' } });
-    t.true(
-      pathExistsSync('.serverless/hello.zip'),
-      'function hello is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello2.zip'),
-      'function hello2 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello3.zip'),
-      'function hello3 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello4.zip'),
-      'function hello4 is packaged'
-    );
-    t.false(
-      pathExistsSync('.serverless/hello5.zip'),
-      'function hello5 is not packaged'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py3.7 can package only requirements of module',
-  async (t) => {
-    process.chdir('tests/individually');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles_hello = await listZipFiles(
-      '.serverless/module1-sls-py-req-test-indiv-dev-hello1.zip'
-    );
-    t.true(
-      zipfiles_hello.includes('handler1.py'),
-      'handler1.py is packaged at root level in function hello1'
-    );
-    t.false(
-      zipfiles_hello.includes('handler2.py'),
-      'handler2.py is NOT packaged at root level in function hello1'
-    );
-    t.true(
-      zipfiles_hello.includes(`pyaml${sep}__init__.py`),
-      'pyaml is packaged in function hello1'
-    );
-    t.true(
-      zipfiles_hello.includes(`boto3${sep}__init__.py`),
-      'boto3 is packaged in function hello1'
-    );
-    t.false(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello1'
-    );
-
-    const zipfiles_hello2 = await listZipFiles(
-      '.serverless/module2-sls-py-req-test-indiv-dev-hello2.zip'
-    );
-    t.true(
-      zipfiles_hello2.includes('handler2.py'),
-      'handler2.py is packaged at root level in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes('handler1.py'),
-      'handler1.py is NOT packaged at root level in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`pyaml${sep}__init__.py`),
-      'pyaml is NOT packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package lambda-decorators using vendor and invidiually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', vendor: './vendor' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged at root level in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged at root level in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged at root level in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
+  t.end();
+});
 
 test(
   "Don't nuke execute perms when using individually",
@@ -2037,7 +1331,7 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.7) }
+  { skip: process.platform === 'win32' }
 );
 
 test(
@@ -2076,41 +1370,33 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || process.platform === 'win32' || !hasPython(3.7) }
+  { skip: !canUseDocker() || process.platform === 'win32' }
 );
 
-test(
-  'py3.7 uses download cache by default option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    t.true(
-      pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
-      'cache directory exists'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses download cache by default option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  t.true(
+    pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
+    'cache directory exists'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 uses download cache by default',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { cacheLocation: '.requirements-cache' } });
-    t.true(
-      pathExistsSync(`.requirements-cache${sep}downloadCacheslspyc${sep}http`),
-      'cache directory exists'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses download cache by default', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { cacheLocation: '.requirements-cache' } });
+  t.true(
+    pathExistsSync(`.requirements-cache${sep}downloadCacheslspyc${sep}http`),
+    'cache directory exists'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses download cache with dockerizePip option',
@@ -2126,7 +1412,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -2144,33 +1430,29 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 uses static and download cache',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
-      'http exists in download-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses static and download cache', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
+    'http exists in download-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses static and download cache with dockerizePip option',
@@ -2194,75 +1476,67 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 uses static cache',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
-      ),
-      '.completed_requirements exists in static-cache'
-    );
+test('py3.7 uses static cache', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
+    ),
+    '.completed_requirements exists in static-cache'
+  );
 
-    // py3.7 checking that static cache actually pulls from cache (by poisoning it)
-    writeFileSync(
-      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
-      'injected new file into static cache folder'
-    );
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('injected_file_is_bad_form'),
-      "static cache is really used when running 'sls package' again"
-    );
+  // py3.7 checking that static cache actually pulls from cache (by poisoning it)
+  writeFileSync(
+    `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
+    'injected new file into static cache folder'
+  );
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('injected_file_is_bad_form'),
+    "static cache is really used when running 'sls package' again"
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  t.end();
+});
 
-test(
-  'py3.7 uses static cache with cacheLocation option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    const cachepath = '.requirements-cache';
-    sls(['package'], { env: { cacheLocation: cachepath } });
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
-      ),
-      '.completed_requirements exists in static-cache'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses static cache with cacheLocation option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  const cachepath = '.requirements-cache';
+  sls(['package'], { env: { cacheLocation: cachepath } });
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
+    ),
+    '.completed_requirements exists in static-cache'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses static cache with dockerizePip & slim option',
@@ -2306,7 +1580,7 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -2332,38 +1606,31 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 can ignore functions defined with `image`',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true' } });
-    t.true(
-      pathExistsSync('.serverless/hello.zip'),
-      'function hello is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello2.zip'),
-      'function hello2 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello3.zip'),
-      'function hello3 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello4.zip'),
-      'function hello4 is packaged'
-    );
-    t.false(
-      pathExistsSync('.serverless/hello5.zip'),
-      'function hello5 is not packaged'
-    );
+test('py3.7 can ignore functions defined with `image`', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true' } });
+  t.true(pathExistsSync('.serverless/hello.zip'), 'function hello is packaged');
+  t.true(
+    pathExistsSync('.serverless/hello2.zip'),
+    'function hello2 is packaged'
+  );
+  t.true(
+    pathExistsSync('.serverless/hello3.zip'),
+    'function hello3 is packaged'
+  );
+  t.true(
+    pathExistsSync('.serverless/hello4.zip'),
+    'function hello4 is packaged'
+  );
+  t.false(
+    pathExistsSync('.serverless/hello5.zip'),
+    'function hello5 is not packaged'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  t.end();
+});


### PR DESCRIPTION
Python2.7 is EOL for a long time and e.g. AWS doesn't support that runtime for a very long time. The support should still be there for esoteric use cases, but this PR drops test coverage for Python 2.7.  