### PR TITLE
Add support for specifying custom dependency groups in Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ custom:
     requirePoetryLockFile: false
 ```
 
+If your Poetry configuration includes custom dependency groups, they will not be installed automatically. To include them in the deployment package, use the `poetryWithGroups`, `poetryWithoutGroups` and `poetryOnlyGroups` options which wrap `poetry export`'s `--with`, `--without` and `--only` parameters.
+
+```yaml
+custom:
+  pythonRequirements:
+    poetryWithGroups:
+      - internal_dependencies
+      - lambda_dependencies
+```
+
 ### Poetry with git dependencies
 
 Poetry by default generates the exported requirements.txt file with `-e` and that breaks pip with `-t` parameter

--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ class ServerlessPythonRequirements {
         noDeploy: [],
         vendor: '',
         requirePoetryLockFile: false,
+        poetryWithGroups: [],
+        poetryWithoutGroups: [],
+        poetryOnlyGroups: [],
       },
       (this.serverless.service.custom &&
         this.serverless.service.custom.pythonRequirements) ||

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -57,6 +57,15 @@ async function pyprojectTomlToRequirements(modulePath, pluginInstance) {
           '-o',
           'requirements.txt',
           '--with-credentials',
+          ...(options.poetryWithGroups.length
+            ? [`--with=${options.poetryWithGroups.join(',')}`]
+            : []),
+          ...(options.poetryWithoutGroups.length
+            ? [`--without=${options.poetryWithoutGroups.join(',')}`]
+            : []),
+          ...(options.poetryOnlyGroups.length
+            ? [`--only=${options.poetryOnlyGroups.join(',')}`]
+            : []),
         ],
         {
           cwd: moduleProjectPath,

--- a/test.js
+++ b/test.js
@@ -1654,3 +1654,52 @@ test('poetry py3.7 fails packaging if poetry.lock is missing and flag requirePoe
   );
   t.end();
 });
+
+test('poetry py3.7 packages additional optional packages', async (t) => {
+  process.chdir('tests/poetry_packages');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      poetryWithGroups: 'poetryWithGroups',
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
+
+test('poetry py3.7 skips additional optional packages specified in withoutGroups', async (t) => {
+  process.chdir('tests/poetry_packages');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      poetryWithGroups: 'poetryWithGroups',
+      poetryWithoutGroups: 'poetryWithoutGroups',
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
+
+test('poetry py3.7 only installs optional packages specified in onlyGroups', async (t) => {
+  process.chdir('tests/poetry_packages');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      poetryOnlyGroups: 'poetryOnlyGroups',
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.false(zipfiles.includes(`flask${sep}__init__.py`), 'flask is NOT packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});

--- a/tests/poetry_packages/_poetryGroups.yml
+++ b/tests/poetry_packages/_poetryGroups.yml
@@ -1,0 +1,8 @@
+empty: []
+poetryWithGroups:
+  - custom1
+  - custom2
+poetryWithoutGroups:
+  - custom1
+poetryOnlyGroups:
+  - custom2

--- a/tests/poetry_packages/_slimPatterns.yml
+++ b/tests/poetry_packages/_slimPatterns.yml
@@ -1,0 +1,2 @@
+slimPatterns:
+  - '**/__main__.py'

--- a/tests/poetry_packages/handler.py
+++ b/tests/poetry_packages/handler.py
@@ -1,0 +1,5 @@
+import requests
+
+
+def hello(event, context):
+    return requests.get('https://httpbin.org/get').json()

--- a/tests/poetry_packages/package.json
+++ b/tests/poetry_packages/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
+  }
+}

--- a/tests/poetry_packages/pyproject.toml
+++ b/tests/poetry_packages/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "poetry"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+Flask = "^1.0"
+
+[tool.poetry.group.custom1.dependencies]
+bottle = {git = "https://git@github.com/bottlepy/bottle.git", tag = "0.12.16"}
+
+[tool.poetry.group.custom2.dependencies]
+boto3 = "^1.9"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/poetry_packages/serverless.yml
+++ b/tests/poetry_packages/serverless.yml
@@ -1,0 +1,34 @@
+service: sls-py-req-test
+
+provider:
+  name: aws
+  runtime: python3.7
+
+plugins:
+  - serverless-python-requirements
+custom:
+  pythonRequirements:
+    zip: ${env:zip, self:custom.defaults.zip}
+    slim: ${env:slim, self:custom.defaults.slim}
+    slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
+    slimPatternsAppendDefaults: ${env:slimPatternsAppendDefaults, self:custom.defaults.slimPatternsAppendDefaults}
+    dockerizePip: ${env:dockerizePip, self:custom.defaults.dockerizePip}
+    requirePoetryLockFile: ${env:requirePoetryLockFile, false}
+    poetryWithGroups: ${file(./_poetryGroups.yml):${env:poetryWithGroups, "empty"}}
+    poetryWithoutGroups: ${file(./_poetryGroups.yml):${env:poetryWithoutGroups, "empty"}}
+    poetryOnlyGroups: ${file(./_poetryGroups.yml):${env:poetryOnlyGroups, "empty"}}
+  defaults:
+    zip: false
+    slimPatterns: false
+    slimPatternsAppendDefaults: true
+    slim: false
+    dockerizePip: false
+
+package:
+  patterns:
+    - '!**/*'
+    - 'handler.py'
+
+functions:
+  hello:
+    handler: handler.hello


### PR DESCRIPTION
Poetry 1.2+ allows to create custom dependency groups in `pyproject.toml`. However, the [`export`](https://github.com/python-poetry/poetry-plugin-export) plugin (unlike the `install` command) does not include those dependencies by default, even if they're not marked as optional, resulting in them being missing from the Serverless deployment package. This PR introduces three new configuration parameters that directly wrap Poetry's `--with`, `--without` and `--only` parameters and allow to include dependencies from those missing groups in the exported `requirements.txt` file.