### PR TITLE
feat: Support Scaleway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,31 @@ package:
     - '**'
 ```
 
+## Custom Provider Support
+
+### Scaleway
+
+This plugin is compatible with the [Scaleway Serverless Framework Plugin](https://github.com/scaleway/serverless-scaleway-functions) to package dependencies for Python functions deployed on [Scaleway](https://www.scaleway.com/en/serverless-functions/). To use it, add the following to your `serverless.yml`:
+
+```yaml
+provider:
+  name: scaleway
+  runtime: python311
+
+plugins:
+  - serverless-python-requirements
+  - serverless-scaleway-functions
+```
+
+To handle native dependencies, it's recommended to use the Docker builder with the image provided by Scaleway:
+
+```yaml
+custom:
+  pythonRequirements:
+    # Can use any Python version supported by Scaleway
+    dockerImage: rg.fr-par.scw.cloud/scwfunctionsruntimes-public/python-dep:3.11
+```
+
 ## Contributors
 
 - [@dschep](https://github.com/dschep) - Lead developer & original maintainer

--- a/index.js
+++ b/index.js
@@ -72,7 +72,10 @@ class ServerlessPythonRequirements {
     ) {
       options.pythonBin = 'python';
     }
-
+    if (/python3[0-9]+/.test(options.pythonBin)) {
+      // "google" and "scaleway" providers' runtimes uses python3XX
+      options.pythonBin = options.pythonBin.replace(/3([0-9]+)/, '3.$1');
+    }
     if (options.dockerizePip === 'non-linux') {
       options.dockerizePip = process.platform !== 'linux';
     }

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -13,10 +13,16 @@ BbPromise.promisifyAll(fse);
  * Inject requirements into packaged application.
  * @param {string} requirementsPath requirements folder path
  * @param {string} packagePath target package path
+ * @param {string} injectionRelativePath installation directory in target package
  * @param {Object} options our options object
  * @return {Promise} the JSZip object constructed.
  */
-function injectRequirements(requirementsPath, packagePath, options) {
+function injectRequirements(
+  requirementsPath,
+  packagePath,
+  injectionRelativePath,
+  options
+) {
   const noDeploy = new Set(options.noDeploy || []);
 
   return fse
@@ -29,7 +35,13 @@ function injectRequirements(requirementsPath, packagePath, options) {
           dot: true,
         })
       )
-        .map((file) => [file, path.relative(requirementsPath, file)])
+        .map((file) => [
+          file,
+          path.join(
+            injectionRelativePath,
+            path.relative(requirementsPath, file)
+          ),
+        ])
         .filter(
           ([file, relativeFile]) =>
             !file.endsWith('/') &&
@@ -101,6 +113,11 @@ async function injectAllRequirements(funcArtifact) {
     this.serverless.cli.log('Injecting required Python packages to package...');
   }
 
+  let injectionRelativePath = '.';
+  if (this.serverless.service.provider.name == 'scaleway') {
+    injectionRelativePath = 'package';
+  }
+
   try {
     if (this.serverless.service.package.individually) {
       await BbPromise.resolve(this.targetFuncs)
@@ -138,6 +155,7 @@ async function injectAllRequirements(funcArtifact) {
             : injectRequirements(
                 path.join('.serverless', func.module, 'requirements'),
                 func.package.artifact,
+                injectionRelativePath,
                 this.options
               );
         });
@@ -145,6 +163,7 @@ async function injectAllRequirements(funcArtifact) {
       await injectRequirements(
         path.join('.serverless', 'requirements'),
         this.serverless.service.package.artifact || funcArtifact,
+        injectionRelativePath,
         this.options
       );
     }

--- a/test.js
+++ b/test.js
@@ -22,30 +22,30 @@ const initialWorkingDir = process.cwd();
 
 const mkCommand =
   (cmd) =>
-    (args, options = {}) => {
-      options['env'] = Object.assign(
-        { SLS_DEBUG: 'true' },
-        process.env,
-        options['env']
+  (args, options = {}) => {
+    options['env'] = Object.assign(
+      { SLS_DEBUG: 'true' },
+      process.env,
+      options['env']
+    );
+    const { error, stdout, stderr, status } = crossSpawn.sync(
+      cmd,
+      args,
+      options
+    );
+    if (error && !options['noThrow']) {
+      console.error(`Error running: ${quote([cmd, ...args])}`); // eslint-disable-line no-console
+      throw error;
+    }
+    if (status && !options['noThrow']) {
+      console.error('STDOUT: ', stdout.toString()); // eslint-disable-line no-console
+      console.error('STDERR: ', stderr.toString()); // eslint-disable-line no-console
+      throw new Error(
+        `${quote([cmd, ...args])} failed with status code ${status}`
       );
-      const { error, stdout, stderr, status } = crossSpawn.sync(
-        cmd,
-        args,
-        options
-      );
-      if (error && !options['noThrow']) {
-        console.error(`Error running: ${quote([cmd, ...args])}`); // eslint-disable-line no-console
-        throw error;
-      }
-      if (status && !options['noThrow']) {
-        console.error('STDOUT: ', stdout.toString()); // eslint-disable-line no-console
-        console.error('STDERR: ', stderr.toString()); // eslint-disable-line no-console
-        throw new Error(
-          `${quote([cmd, ...args])} failed with status code ${status}`
-        );
-      }
-      return stdout && stdout.toString().trim();
-    };
+    }
+    return stdout && stdout.toString().trim();
+  };
 
 const sls = mkCommand('sls');
 const git = mkCommand('git');
@@ -421,7 +421,7 @@ test(
     );
     t.true(
       zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-      0,
+        0,
       '__main__.py files are packaged'
     );
     t.end();
@@ -1722,7 +1722,13 @@ test('py3.7 injects dependencies into `package` folder when using scaleway provi
   npm(['i', path]);
   sls(['package'], { env: {} });
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-  t.true(zipfiles.includes(`package${sep}flask${sep}__init__.py`), 'flask is packaged');
-  t.true(zipfiles.includes(`package${sep}boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.true(
+    zipfiles.includes(`package${sep}flask${sep}__init__.py`),
+    'flask is packaged'
+  );
+  t.true(
+    zipfiles.includes(`package${sep}boto3${sep}__init__.py`),
+    'boto3 is packaged'
+  );
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -1718,8 +1718,8 @@ test('poetry py3.7 only installs optional packages specified in onlyGroups', asy
 
 test('py3.7 injects dependencies into `package` folder when using scaleway provider', async (t) => {
   process.chdir('tests/scaleway_provider');
-  const path = npm(['pack', '../..']);
-  npm(['i', path]);
+  npm(['pack', '../..']);
+  npm(['i']); // install the serverless-scaleway-functions plugin
   sls(['package'], { env: {} });
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(

--- a/tests/scaleway_provider/_slimPatterns.yml
+++ b/tests/scaleway_provider/_slimPatterns.yml
@@ -1,0 +1,2 @@
+slimPatterns:
+  - '**/__main__.py'

--- a/tests/scaleway_provider/handler.py
+++ b/tests/scaleway_provider/handler.py
@@ -1,0 +1,5 @@
+import requests
+
+
+def hello(event, context):
+    return requests.get('https://httpbin.org/get').json()

--- a/tests/scaleway_provider/package.json
+++ b/tests/scaleway_provider/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz",
+    "serverless-scaleway-functions": "^0.4.5"
+  }
+}

--- a/tests/scaleway_provider/package.json
+++ b/tests/scaleway_provider/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz",
-    "serverless-scaleway-functions": "^0.4.5"
+    "serverless-scaleway-functions": "^0.4.7"
   }
 }

--- a/tests/scaleway_provider/package.json
+++ b/tests/scaleway_provider/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz",
-    "serverless-scaleway-functions": "^0.4.7"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz",
+    "serverless-scaleway-functions": "^0.4.8"
   }
 }

--- a/tests/scaleway_provider/requirements.txt
+++ b/tests/scaleway_provider/requirements.txt
@@ -1,0 +1,3 @@
+flask==0.12.5
+bottle
+boto3

--- a/tests/scaleway_provider/serverless.yml
+++ b/tests/scaleway_provider/serverless.yml
@@ -1,0 +1,34 @@
+service: sls-py-req-test
+
+configValidationMode: off
+
+provider:
+  name: scaleway
+  runtime: python37
+
+plugins:
+  - serverless-python-requirements
+  - serverless-scaleway-functions
+
+custom:
+  pythonRequirements:
+    zip: ${env:zip, self:custom.defaults.zip}
+    slim: ${env:slim, self:custom.defaults.slim}
+    slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
+    slimPatternsAppendDefaults: ${env:slimPatternsAppendDefaults, self:custom.defaults.slimPatternsAppendDefaults}
+    dockerizePip: ${env:dockerizePip, self:custom.defaults.dockerizePip}
+  defaults:
+    zip: false
+    slimPatterns: false
+    slimPatternsAppendDefaults: true
+    slim: false
+    dockerizePip: false
+
+package:
+  patterns:
+    - '!**/*'
+    - 'handler.py'
+
+functions:
+  hello:
+    handler: handler.hello


### PR DESCRIPTION
Hello :wave: ,

First of all, thanks for this amazing plugin! It's so great that some peeps have been trying to use it with different Serverless providers.

Currently this plugin has some minor issues when using the "google" or "scaleway" Serverless providers. Here are some of the issues reported previously: #651 and #340

Here are two noticeable issues:
- Loading the python binary from the runtime does not work for providers that uses a `python3XX` runtime format
- Scaleway expects vendored dependencies to be in a `package` folder (https://www.scaleway.com/en/docs/compute/functions/how-to/package-function-in-zip#additional-dependencies)

This PR is a quick fix to address those two issues. Thank you!