### PR TITLE
Support recursively adding files to serverless package

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,16 @@ zipinfo .serverless/xxx.zip
 
 If you can't see the library, you might need to adjust your package include/exclude configuration in `serverless.yml`.
 
+If you would like to recursively include a directory and all of its contents,
+prepend `-r ` to the file list member:
+
+```yaml
+custom:
+  pythonRequirements:
+    dockerExtraFiles:
+      - -r /path/to/additional/dependencies/
+```
+
 ## Optimising packaging time
 
 If you wish to exclude most of the files in your project, and only include the source files of your lambdas and their dependencies you may well use an approach like this:

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -339,7 +339,13 @@ async function installRequirements(targetFolder, pluginInstance) {
       }
 
       for (let path of options.dockerExtraFiles) {
-        pipCmds.push(['cp', path, '/var/task/']);
+          let cmd = ['cp', path, '/var/task/'];
+          // Copy recursively if -r option was specified
+          if (path.startsWith('-r ')) {
+              path = path.split(' ')[1];
+              cmd = ['cp', '-r', path, '/var/task/']
+          }
+          pipCmds.push(cmd);
       }
 
       if (process.platform === 'linux') {


### PR DESCRIPTION
Reopening rebased against master as this is still a feature we would love to have merged upstream.


Closes: https://github.com/serverless/serverless-python-requirements/issues/542
Closes: https://github.com/serverless/serverless-python-requirements/pull/544