### PR TITLE
Support noDeploy option when use layers

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -2,7 +2,7 @@ const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const path = require('path');
 const JSZip = require('jszip');
-const { writeZip, addTree } = require('./zipTree');
+const { writeZip, addTreeNoDeploy } = require('./zipTree');
 const { sha256Path, getRequirementsLayerPath } = require('./shared');
 
 BbPromise.promisifyAll(fse);
@@ -39,9 +39,10 @@ function zipRequirements() {
   } else {
     const rootZip = new JSZip();
     const runtimepath = 'python';
+    const noDeploy = new Set(this.options.noDeploy || []);
 
     promises.push(
-      addTree(rootZip.folder(runtimepath), src).then(() =>
+      addTreeNoDeploy(rootZip.folder(runtimepath), src, noDeploy).then(() =>
         writeZip(rootZip, zipCachePath)
       )
     );

--- a/lib/zipTree.js
+++ b/lib/zipTree.js
@@ -33,6 +33,36 @@ function addTree(zip, src) {
 }
 
 /**
+ * Add a directory recursively to a zip file. Files in src will be added to the top folder of zip.
+ * @param {JSZip} zip a zip object in the folder you want to add files to.
+ * @param {string} src the source folder.
+ * @param {Object} noDeploy the source folder.
+ * @return {Promise} a promise offering the original JSZip object.
+ */
+function addTreeNoDeploy(zip, src, noDeploy) {
+  const srcN = path.normalize(src);
+
+  return fse
+    .readdirAsync(srcN)
+    .filter(name => !noDeploy.has(name))
+    .map((name) => {
+      const srcPath = path.join(srcN, name);
+
+      return fse.statAsync(srcPath).then((stat) => {
+        if (stat.isDirectory()) {
+          return addTreeNoDeploy(zip.folder(name), srcPath, noDeploy);
+        } else {
+          const opts = { date: stat.mtime, unixPermissions: stat.mode };
+          return fse
+            .readFileAsync(srcPath)
+            .then((data) => zip.file(name, data, opts));
+        }
+      });
+    })
+    .then(() => zip); // Original zip for chaining.
+}
+
+/**
  * Write zip contents to a file.
  * @param {JSZip} zip the zip object
  * @param {string} targetPath path to write the zip file to.
@@ -81,4 +111,4 @@ function zipFile(zip, zipPath, bufferPromise, fileOpts) {
     .then(() => zip);
 }
 
-module.exports = { addTree, writeZip, zipFile };
+module.exports = { addTree, writeZip, zipFile , addTreeNoDeploy };

--- a/lib/zipTree.js
+++ b/lib/zipTree.js
@@ -36,7 +36,7 @@ function addTree(zip, src) {
  * Add a directory recursively to a zip file. Files in src will be added to the top folder of zip.
  * @param {JSZip} zip a zip object in the folder you want to add files to.
  * @param {string} src the source folder.
- * @param {Object} noDeploy the source folder.
+ * @param {Object} noDeploy
  * @return {Promise} a promise offering the original JSZip object.
  */
 function addTreeNoDeploy(zip, src, noDeploy) {


### PR DESCRIPTION
This change allows use of noDeploy option with the layers.

Should resolve:
https://github.com/serverless/serverless-python-requirements/issues/577