### PR TITLE
fix: Remove outdated Pipenv requirements flag

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,11 @@ jobs:
     strategy:
       matrix:
         sls-version: [2, 3]
-        pipenv-version: ['2022.8.5', '2022.8.13']
+        pipenv-version: ['2022.8.5', '2022.8.13', '2023.7.4', '2023.7.9']
+        # pipenv 2202.8.13 marks deprecation of pipenv lock --requirements
+        # https://github.com/pypa/pipenv/blob/30067b458bd7a429f242736b7fde40c9bd4d4f14/CHANGELOG.rst#2022813-2022-08-13
+        # pipenv 2023.7.9 marks deprecation of pipenv lock --keep-outdated
+        # https://github.com/pypa/pipenv/blob/30067b458bd7a429f242736b7fde40c9bd4d4f14/CHANGELOG.rst#202379-2023-07-09
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -95,7 +99,7 @@ jobs:
     strategy:
       matrix:
         sls-version: [2, 3]
-        pipenv-version: ['2022.8.5', '2022.8.13']
+        pipenv-version: ['2022.8.5', '2022.8.13', '2023.7.4', '2023.7.9']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -149,7 +153,7 @@ jobs:
     strategy:
       matrix:
         sls-version: [2, 3]
-        pipenv-version: ['2022.8.5', '2022.8.13']
+        pipenv-version: ['2022.8.5', '2022.8.13', '2023.7.4', '2023.7.9']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,10 +4,7 @@ name: Validate
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+    branches: [master]
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,10 @@ name: Validate
 
 on:
   pull_request:
-    branches: [master]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   FORCE_COLOR: 1

--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -77,15 +77,22 @@ async function pipfileToRequirements() {
 
     if (semver.gt(pipenvVersion, LEGACY_PIPENV_VERSION)) {
       // Using new pipenv syntax ( >= 2022.8.13)
+      // Generate requirements from existing lock file.
+      // See: https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
       try {
-        await spawn('pipenv', ['lock', '--keep-outdated'], {
+        await spawn('pipenv', ['requirements'], {
           cwd: this.servicePath,
         });
       } catch (e) {
         const stderrBufferContent =
           (e.stderrBuffer && e.stderrBuffer.toString()) || '';
-        if (stderrBufferContent.includes('must exist to use')) {
+        if (stderrBufferContent.includes('FileNotFoundError')) {
           // No previous Pipfile.lock, we will try to generate it here
+          if (this.log) {
+            this.log.warning('No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.');
+          } else {
+            this.serverless.cli.log('WARNING: No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.');
+          }
           await spawn('pipenv', ['lock'], {
             cwd: this.servicePath,
           });

--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -89,9 +89,13 @@ async function pipfileToRequirements() {
         if (stderrBufferContent.includes('FileNotFoundError')) {
           // No previous Pipfile.lock, we will try to generate it here
           if (this.log) {
-            this.log.warning('No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.');
+            this.log.warning(
+              'No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.'
+            );
           } else {
-            this.serverless.cli.log('WARNING: No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.');
+            this.serverless.cli.log(
+              'WARNING: No Pipfile.lock found! Review https://pipenv.pypa.io/en/latest/pipfile/ for recommendations.'
+            );
           }
           await spawn('pipenv', ['lock'], {
             cwd: this.servicePath,

--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -80,7 +80,7 @@ async function pipfileToRequirements() {
       // Generate requirements from existing lock file.
       // See: https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
       try {
-        await spawn('pipenv', ['requirements'], {
+        res = await spawn('pipenv', ['requirements'], {
           cwd: this.servicePath,
         });
       } catch (e) {
@@ -96,14 +96,13 @@ async function pipfileToRequirements() {
           await spawn('pipenv', ['lock'], {
             cwd: this.servicePath,
           });
+          res = await spawn('pipenv', ['requirements'], {
+            cwd: this.servicePath,
+          });
         } else {
           throw e;
         }
       }
-
-      res = await spawn('pipenv', ['requirements'], {
-        cwd: this.servicePath,
-      });
     } else {
       // Falling back to legacy pipenv syntax
       res = await spawn(

--- a/tests/base/package.json
+++ b/tests/base/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/individually/package.json
+++ b/tests/individually/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.1.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/non_build_pyproject/package.json
+++ b/tests/non_build_pyproject/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/non_poetry_pyproject/package.json
+++ b/tests/non_poetry_pyproject/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/pipenv/package.json
+++ b/tests/pipenv/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/poetry/package.json
+++ b/tests/poetry/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }

--- a/tests/poetry_individually/package.json
+++ b/tests/poetry_individually/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-5.3.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-6.0.0.tgz"
   }
 }


### PR DESCRIPTION
Removes use of the now-removed flag `--keep-outdated` on pipenv lock.  See [pipenv 2023.7.9 release notes](https://github.com/pypa/pipenv/releases/tag/v2023.7.9).

Rather than re-generating or potentially updating a user's Pipenv.lock file, it'll go straight into trying to build the requirements file.

The pre-existing behavior was that if the Pipfile.lock file was missing, that the plugin will generate one.  Since this is likely undesireable, added a warning log message pointing a user to the Pipenv documenation on how to address it.

Also updates github-actions test matrix to include the before/after of this pipenv behavior change.

Closes: #779