### PR TITLE
ci: Temporarily disable test run on integrate

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -10,61 +10,9 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  linuxNode14:
-    name: '[Linux] Node.js 14: Unit tests'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        sls-version: [2, 3]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Retrieve dependencies from cache
-        id: cacheNpm
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.npm
-            node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install Node.js and npm
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Check python version
-        run: |
-          python --version
-
-      - name: Install setuptools
-        run: python -m pip install --force setuptools wheel
-
-      - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
-
-      - name: Install serverless
-        run: npm install -g serverless@${{ matrix.sls-version }}
-
-      - name: Install dependencies
-        if: steps.cacheNpm.outputs.cache-hit != 'true'
-        run: |
-          npm update --no-save
-          npm update --save-dev --no-save
-      - name: Unit tests
-        run: npm test
-
   tagIfNewVersion:
     name: Tag if new version
     runs-on: ubuntu-latest
-    needs: [linuxNode14]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
In order to unblock release `v6.0.1`

Related: #798 