### PR TITLE
Fix for spitting error out when pip fails

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -423,8 +423,8 @@ async function installRequirements(targetFolder, pluginInstance) {
         }
 
         if (log) {
-          log.info(`Stdout: ${e.stdoutBuffer}`);
-          log.info(`Stderr: ${e.stderrBuffer}`);
+          log.error(`Stdout: ${e.stdoutBuffer}`);
+          log.error(`Stderr: ${e.stderrBuffer}`);
         } else {
           serverless.cli.log(`Stdout: ${e.stdoutBuffer}`);
           serverless.cli.log(`Stderr: ${e.stderrBuffer}`);


### PR DESCRIPTION
This should help with this issue: https://github.com/serverless/serverless-python-requirements/issues/663

Currently, if pip fails, you just get a "Exited with code 1" that is entirely unhelpful and leads to people thinking they have other issues than dependency. 

With this fix, it will spit out the error (if there is one)