### PR TITLE
Add docker rootless feature flag and its implementation for supporting docke rootless environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ class ServerlessPythonRequirements {
         dockerBuildCmdExtraArgs: [],
         dockerRunCmdExtraArgs: [],
         dockerExtraFiles: [],
+        dockerRootless: false,
         useStaticCache: true,
         useDownloadCache: true,
         cacheLocation: false,

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -327,12 +327,17 @@ async function installRequirements(targetFolder, pluginInstance) {
         }
         // Install requirements with pip
         // Set the ownership of the current folder to user
-        pipCmds.push([
-          'chown',
-          '-R',
-          `${process.getuid()}:${process.getgid()}`,
-          '/var/task',
-        ]);
+        // If you use docker-rootless, you don't need to set the ownership
+        if (options.dockerRootless !== true) {
+          pipCmds.push([
+            'chown',
+            '-R',
+            `${process.getuid()}:${process.getgid()}`,
+            '/var/task',
+          ]);
+        } else {
+          pipCmds.push(['chown', '-R', '0:0', '/var/task']);
+        }
       } else {
         // Use same user so --cache-dir works
         dockerCmd.push('-u', await getDockerUid(bindPath, pluginInstance));
@@ -345,12 +350,16 @@ async function installRequirements(targetFolder, pluginInstance) {
       if (process.platform === 'linux') {
         if (options.useDownloadCache) {
           // Set the ownership of the download cache dir back to user
-          pipCmds.push([
-            'chown',
-            '-R',
-            `${process.getuid()}:${process.getgid()}`,
-            dockerDownloadCacheDir,
-          ]);
+          if (options.dockerRootless !== true) {
+            pipCmds.push([
+              'chown',
+              '-R',
+              `${process.getuid()}:${process.getgid()}`,
+              dockerDownloadCacheDir,
+            ]);
+          } else {
+            pipCmds.push(['chown', '-R', '0:0', dockerDownloadCacheDir]);
+          }
         }
       }
 


### PR DESCRIPTION
resolve: #817 

Add feature flag `dockerRootless` and default value `false`. 

Change `lib/pip.js` file permission change logic for supporting docker rootless environment. 

I think that its better add some document about this in `README.md`