### PR TITLE
Bumped node version as it was giving sls errors

### DIFF
--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -47,7 +47,7 @@ functions:
     handler: handler.hello
   hello3:
     handler: handler.hello
-    runtime: nodejs8.10
+    runtime: nodejs14.x
   hello4:
     handler: fn2_handler.hello
     module: fn2


### PR DESCRIPTION
I was getting invalid runtime errors with the code in place. it looks like node8.10 has been removed from support for serverless (/aws). This bumps the version up to nodejs14.x for the one serverless function that defined it


Warning: Invalid configuration encountered
  at 'functions.hello3.runtime': must be equal to one of the allowed values [dotnet6, go1.x, java17, java11, java8, java8.al2, nodejs14.x, nodejs16.x, nodejs18.x, nodejs20.x, provided, provided.al2, provided.al2023, python3.7, python3.8, python3.9, python3.10, python3.11, ruby2.7, ruby3.2]