### PR TITLE
feat: support custom git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ custom:
 With `Dockerfile` the path to the Dockerfile that must be in the current folder (or a subfolder).
 Please note the `dockerImage` and the `dockerFile` are mutually exclusive.
 
+To install requirements with custom git settings (e.g., to map private repositories with
+authentication parameters), add the following to your `serverless.yml`:
+
+```yaml
+custom:
+  pythonRequirements:
+    dockerizePip: true
+    dockerGit: true
+```
+
+The `dockerGit` option will mount your `$HOME/.gitconfig` as a volume in the docker container.
+
+In case you want to use a different git configuration, you can specify the path (absolute) to it through `dockerGitConfig` option:
+
+```yaml
+custom:
+  pythonRequirements:
+    dockerizePip: true
+    dockerGit: true
+    dockerGitConfig: /home/.git/config
+```
+
 To install requirements from private git repositories, add the following to your `serverless.yml`:
 
 ```yaml

--- a/index.js
+++ b/index.js
@@ -44,6 +44,8 @@ class ServerlessPythonRequirements {
         dockerizePip: false,
         dockerSsh: false,
         dockerPrivateKey: null,
+        dockerGit: false,
+        dockerGitOptions: null,
         dockerImage: null,
         dockerFile: null,
         dockerEnv: false,
@@ -86,6 +88,7 @@ class ServerlessPythonRequirements {
     if (
       !options.dockerizePip &&
       (options.dockerSsh ||
+        options.dockerGit ||
         options.dockerImage ||
         options.dockerFile ||
         options.dockerPrivateKey)

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -288,13 +288,11 @@ async function installRequirements(targetFolder, pluginInstance, funcOptions) {
 
       if (options.dockerGit) {
         const homePath = require('os').homedir();
-        const gitConfigPath = options.dockerGitConfig || `${homePath}/.gitconfig`;
+        const gitConfigPath =
+          options.dockerGitConfig || `${homePath}/.gitconfig`;
 
         // Mount necessary git files to work with private repos
-        dockerCmd.push(
-          '-v',
-          `${gitConfigPath}:/root/.gitconfig:z`
-        );
+        dockerCmd.push('-v', `${gitConfigPath}:/root/.gitconfig:z`);
       }
 
       // If we want a download cache...

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -286,6 +286,17 @@ async function installRequirements(targetFolder, pluginInstance, funcOptions) {
         );
       }
 
+      if (options.dockerGit) {
+        const homePath = require('os').homedir();
+        const gitConfigPath = options.dockerGitConfig || `${homePath}/.gitconfig`;
+
+        // Mount necessary git files to work with private repos
+        dockerCmd.push(
+          '-v',
+          `${gitConfigPath}:/root/.gitconfig:z`
+        );
+      }
+
       // If we want a download cache...
       const dockerDownloadCacheDir = '/var/useDownloadCache';
       if (options.useDownloadCache) {

--- a/test.js
+++ b/test.js
@@ -247,7 +247,7 @@ test(
     t.end();
   },
   { skip: !canUseDocker() || brokenOn('win32') }
-)
+);
 
 test('default pythonBin can package flask with default options', async (t) => {
   process.chdir('tests/base');

--- a/test.js
+++ b/test.js
@@ -223,6 +223,32 @@ test(
   { skip: !canUseDocker() || brokenOn('win32') }
 );
 
+test(
+  'dockerGitConfig option correctly resolves docker command',
+  async (t) => {
+    process.chdir('tests/base');
+    const path = npm(['pack', '../..']);
+    npm(['i', path]);
+    const stdout = sls(['package'], {
+      noThrow: true,
+      env: {
+        dockerizePip: true,
+        dockerGit: true,
+        dockerGitConfig: `${__dirname}${sep}tests${sep}base${sep}custom_gitconfig`,
+        dockerImage: 'break the build to log the command',
+      },
+    });
+    t.true(
+      stdout.includes(
+        `-v ${__dirname}${sep}tests${sep}base${sep}custom_gitconfig:/root/.gitconfig:z`
+      ),
+      'docker command properly resolved'
+    );
+    t.end();
+  },
+  { skip: !canUseDocker() || brokenOn('win32') }
+)
+
 test('default pythonBin can package flask with default options', async (t) => {
   process.chdir('tests/base');
   const path = npm(['pack', '../..']);

--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -12,6 +12,8 @@ custom:
     dockerizePip: ${env:dockerizePip, self:custom.defaults.dockerizePip}
     dockerSsh: ${env:dockerSsh, self:custom.defaults.dockerSsh}
     dockerPrivateKey: ${env:dockerPrivateKey, self:custom.defaults.dockerPrivateKey}
+    dockerGit: ${env:dockerGit, self:custom.defaults.dockerGit}
+    dockerGitOptions: ${env:dockerGitOptions, self:custom.defaults.dockerGitOptions}
     dockerImage: ${env:dockerImage, self:custom.defaults.dockerImage}
     slim: ${env:slim, self:custom.defaults.slim}
     slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
@@ -29,6 +31,8 @@ custom:
     dockerizePip: false
     dockerSsh: false
     dockerPrivateKey: ''
+    dockerGit: false
+    dockerGitOptions: ''
     dockerImage: ''
     individually: false
     useStaticCache: true


### PR DESCRIPTION
This allows for, among other things, relying on git URL mappings, which can normalize protocols:

```sh
git config --global url."ssh://git@github.com".insteadOf "https://github.com"
```

Or add credentials from environment variables for a CI tool:

```sh
git config --global \
    url."https://${USERNAME}:${PASSWORD}@github.com/${OWNER}/".insteadOf \
    "https://github.com/${OWNER}/"
```

I have a project relying on this change and it is working spendidly.