### PR TITLE
Document required Poetry v2 export plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ custom:
 
 ## :sparkles::pencil::sparkles: Poetry support
 
-If you include a `pyproject.toml` and have `poetry` installed instead of a `requirements.txt` this will use
-`poetry export --without-hashes -f requirements.txt -o requirements.txt --with-credentials` to generate them. It is fully compatible with all options such as `zip` and
+If you include a `pyproject.toml` and have `poetry` installed instead of a `requirements.txt`, this will use
+`poetry export --without-hashes -f requirements.txt -o requirements.txt --with-credentials` to generate them 
+(**Note**: as of Poetry v2, you must explicitly add the [poetry-plugin-export](https://github.com/python-poetry/poetry-plugin-export) plugin to your project since the `poetry export` command is no longer available by default).
+It is fully compatible with all options such as `zip` and
 `dockerizePip`. If you don't want this plugin to generate it for you, set the following option:
 
 ```yaml


### PR DESCRIPTION
The `poetry export` command is not included by default as of Poetry v2 ([read more](https://python-poetry.org/docs/cli/#export)). Added a note to the readme so users know they need to explicitly install the corresponding Poetry [plugin](https://github.com/python-poetry/poetry-plugin-export) in such cases.